### PR TITLE
refactor(pool): cache dns lookup if domain is provided for connect

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -2,6 +2,8 @@
 
 var inherits = require('util').inherits,
   EventEmitter = require('events').EventEmitter,
+  dns = require('dns'),
+  net = require('net'),
   Connection = require('./connection'),
   MongoError = require('../error'),
   Logger = require('./logger'),
@@ -581,32 +583,17 @@ Pool.prototype.connect = function() {
   }
 
   var self = this;
-  // Transition to connecting state
-  stateTransition(this, CONNECTING);
-  // Create an array of the arguments
-  var args = Array.prototype.slice.call(arguments, 0);
-  // Create a connection
-  var connection = new Connection(messageHandler(self), this.options);
-  // Add to list of connections
-  this.connectingConnections.push(connection);
-  // Add listeners to the connection
-  connection.once('connect', function(connection) {
-    if(self.state == DESTROYED || self.state == DESTROYING) return self.destroy();
-
-    // Apply any store credentials
-    reauthenticate(self, connection, function(err) {
+  function _connect(args) {
+    // Create a connection
+    var connection = new Connection(messageHandler(self), self.options);
+    // Add to list of connections
+    self.connectingConnections.push(connection);
+    // Add listeners to the connection
+    connection.once('connect', function(connection) {
       if(self.state == DESTROYED || self.state == DESTROYING) return self.destroy();
 
-      // We have an error emit it
-      if(err) {
-        // Destroy the pool
-        self.destroy();
-        // Emit the error
-        return self.emit('error', err);
-      }
-
-      // Authenticate
-      authenticate(self, args, connection, function(err) {
+      // Apply any store credentials
+      reauthenticate(self, connection, function(err) {
         if(self.state == DESTROYED || self.state == DESTROYING) return self.destroy();
 
         // We have an error emit it
@@ -616,30 +603,63 @@ Pool.prototype.connect = function() {
           // Emit the error
           return self.emit('error', err);
         }
-        // Set connected mode
-        stateTransition(self, CONNECTED);
 
-        // Move the active connection
-        moveConnectionBetween(connection, self.connectingConnections, self.availableConnections);
+        // Authenticate
+        authenticate(self, args, connection, function(err) {
+          if(self.state == DESTROYED || self.state == DESTROYING) return self.destroy();
 
-        // Emit the connect event
-        self.emit('connect', self);
+          // We have an error emit it
+          if(err) {
+            // Destroy the pool
+            self.destroy();
+            // Emit the error
+            return self.emit('error', err);
+          }
+          // Set connected mode
+          stateTransition(self, CONNECTED);
+
+          // Move the active connection
+          moveConnectionBetween(connection, self.connectingConnections, self.availableConnections);
+
+          // Emit the connect event
+          self.emit('connect', self);
+        });
       });
     });
-  });
 
-  // Add error handlers
-  connection.once('error', connectionFailureHandler(this, 'error'));
-  connection.once('close', connectionFailureHandler(this, 'close'));
-  connection.once('timeout', connectionFailureHandler(this, 'timeout'));
-  connection.once('parseError', connectionFailureHandler(this, 'parseError'));
+    // Add error handlers
+    connection.once('error', connectionFailureHandler(self, 'error'));
+    connection.once('close', connectionFailureHandler(self, 'close'));
+    connection.once('timeout', connectionFailureHandler(self, 'timeout'));
+    connection.once('parseError', connectionFailureHandler(self, 'parseError'));
 
-  try {
-    connection.connect();
-  } catch(err) {
-    // SSL or something threw on connect
-    process.nextTick(function() {
-      self.emit('error', err);
+    try {
+      connection.connect();
+    } catch(err) {
+      // SSL or something threw on connect
+      process.nextTick(function() {
+        self.emit('error', err);
+      });
+    }
+  }
+
+  // Transition to connecting state
+  stateTransition(this, CONNECTING);
+  // Create an array of the arguments
+  var args = Array.prototype.slice.call(arguments, 0);
+
+  if (net.isIP(this.options.host)) {
+    _connect(args);
+  } else {
+    dns.lookup(this.options.host, function(err, address) {
+      if (err) {
+        this.emit('error', err);
+        return;
+      }
+
+      // cache lookups for future use
+      self.options.host = address;
+      _connect(args);
     });
   }
 }

--- a/test/tests/functional/pool_tests.js
+++ b/test/tests/functional/pool_tests.js
@@ -902,3 +902,24 @@ exports['Should correctly exit _execute loop when single avialable connection is
     pool.connect();
   }
 }
+
+exports['Should store the cached result of dns lookups'] = {
+  test: function(configuration, test) {
+    var Pool = require('../../../lib/connection/pool')
+      , bson = require('bson');
+
+    // Attempt to connect
+    var pool = new Pool({
+      host: 'localhost', port: 9999, bson: new bson()
+    })
+
+    setTimeout(function() {
+      test.equal('127.0.0.1', pool.options.host);
+      pool.destroy(true);
+      test.done();
+    }, 1000);
+
+    // Start connection
+    pool.connect();
+  }
+}


### PR DESCRIPTION
NODE-942

Not sure if this needs to change anywhere else in the pool code. It does look like there are some potentially refactorable similarities between the code in `Pool.connect` and `createConnection`, but didn't feel like this was the platform to make any such changes.