### PR TITLE
Fix issue in Response.parse when the underlying cursor has been closed

### DIFF
--- a/lib/connection/commands.js
+++ b/lib/connection/commands.js
@@ -501,6 +501,11 @@ Response.prototype.parse = function(options) {
     // Deserialize but keep the array of documents in non-parsed form
     var doc = this.bson.deserialize(document, _options);
 
+    // Make sure we have a cursor
+    if (!doc.cursor) {
+      return;
+    }
+
     // Get the documents
     this.documents = doc.cursor[documentsReturnedIn];
     this.numberReturned = this.documents.length;


### PR DESCRIPTION
This PR resolves a bug when calling `cancel` on a `cursor` while using `forEach` to iterate over a result set. In that situation, the result of `deserialize` on commands.js line #502 is something like
```
{ ok: 0,
  errmsg: 'Cursor not found, cursor id: 38233323205',
  code: 43 }
```

I'm not sure if this is the best solution, but it's a possible solution :)