### PR TITLE
Improve handling for autoReconnect: false with timeouts

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -539,6 +539,10 @@ var nextFunction = function(self, callback) {
         // Topology was destroyed, so don't try to wait for it to reconnect
         return callback(new MongoError('Topology was destroyed'));
       }
+      if (!self.s.topologyOptions.reconnect) {
+        // Reconnect is disabled, so we'll never reconnect
+        return callback(new MongoError('no connection available'));
+      }
       return self.disconnectHandler.addObjectAndMethod('cursor', self, 'next', [callback], callback);
     }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -534,16 +534,19 @@ var nextFunction = function(self, callback) {
   if(!self.cursorState.init) {
     // Topology is not connected, save the call in the provided store to be
     // Executed at some point when the handler deems it's reconnected
-    if(!self.topology.isConnected(self.options) && self.disconnectHandler != null) {
-      if (self.topology.isDestroyed()) {
-        // Topology was destroyed, so don't try to wait for it to reconnect
-        return callback(new MongoError('Topology was destroyed'));
-      }
-      if (!self.s.topologyOptions.reconnect) {
+    if(!self.topology.isConnected(self.options)) {
+      if (!self.topology.s.options.reconnect) {
         // Reconnect is disabled, so we'll never reconnect
         return callback(new MongoError('no connection available'));
       }
-      return self.disconnectHandler.addObjectAndMethod('cursor', self, 'next', [callback], callback);
+      if (self.disconnectHandler != null) {
+        if (self.topology.isDestroyed()) {
+          // Topology was destroyed, so don't try to wait for it to reconnect
+          return callback(new MongoError('Topology was destroyed'));
+        }
+
+        return self.disconnectHandler.addObjectAndMethod('cursor', self, 'next', [callback], callback);
+      }
     }
 
     try {

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -188,7 +188,7 @@ function configureWireProtocolHandler(self, ismaster) {
 function disconnectHandler(self, type, ns, cmd, options, callback) {
   // Topology is not connected, save the call in the provided store to be
   // Executed at some point when the handler deems it's reconnected
-  if(!self.s.pool.isConnected() && self.s.disconnectHandler != null && !options.monitoring) {
+  if(!self.s.pool.isConnected() && self.s.options.reconnect && self.s.disconnectHandler != null && !options.monitoring) {
     self.s.disconnectHandler.add(type, ns, cmd, options, callback);
     return true;
   }


### PR DESCRIPTION
@adriaanmeuris and @bendytree 's repro for Automattic/mongoose#4513 helped uncover a few couple nasty edge cases with how mongodb-core handles `autoReconnect: false`.

First up, with the server topology, the below script will hang forever, because the `count()` call will wait forever for a reconnect.

```javascript
const mongodb = require('mongodb');

run().catch(error => console.error('Uncaught error', error.stack));

async function run() {
  const db = await mongodb.MongoClient.connect('mongodb://localhost:27017/test', {
    socketTimeoutMS: 500,
    poolSize: 1,
    autoReconnect: false
  });

  db.on('timeout', function() {
    console.log('Got timeout');
  });

  db.on('disconnected', function() {
    console.log('Disconnected');
  });

  await db.dropDatabase();

  await db.collection('Test').insertOne({});

  try {
    await db.collection('Test').find({ $where: 'sleep(2000) || true' }).toArray();
  } catch(error) {
    console.log('Got error', error);
  }

  try {
    console.log('Before');
    await db.collection('Test').count();
    console.log('After', docs);
  } catch(error) {
    console.log('Got 2nd error', error);
  }

  console.log('done');
}
```

There's a similar issue with cursor, it'll just wait forever for a reconnect that the driver will never attempt.

```javascript
const mongodb = require('mongodb');

run().catch(error => console.error('Uncaught error', error.stack));

async function run() {
  const db = await mongodb.MongoClient.connect('mongodb://localhost:27017/test', {
    socketTimeoutMS: 500,
    poolSize: 1,
    autoReconnect: false
  });

  db.on('timeout', function() {
    console.log('Got timeout');
  });

  db.on('disconnected', function() {
    console.log('Disconnected');
  });

  await db.dropDatabase();

  await db.collection('Test').insertOne({});

  try {
    await db.collection('Test').find({ $where: 'sleep(2000) || true' }).toArray();
  } catch(error) {
    console.log('Got error', error);
  }

  try {
    console.log('Before');
    await db.collection('Test').find().toArray();
    console.log('After', docs);
  } catch(error) {
    console.log('Got 2nd error', error);
  }

  console.log('done');
}
```