### PR TITLE
feat(driver-sessions): Implement driver sessions for the core driver

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = {
   Logger: require('./lib/connection/logger'),
   Cursor: require('./lib/cursor'),
   ReadPreference: require('./lib/topologies/read_preference'),
+  Sessions: require('./lib/sessions'),
   BSON: BSON,
   // Raw operations
   Query: require('./lib/connection/commands').Query,
@@ -33,3 +34,4 @@ module.exports = {
   GSSAPI: require('./lib/auth/gssapi'),
   ScramSHA1: require('./lib/auth/scram')
 };
+

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -1164,6 +1164,9 @@ Pool.prototype.write = function(commands, options, cb) {
       }
 
       sessionOptions.lsid = operation.session.id;
+
+      // update the `lastUse` of the acquired ServerSession
+      operation.session.serverSession.lastUse = Date.now();
     }
 
     // decorate the commands with session-specific details

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -287,7 +287,6 @@ function connectionFailureHandler(self, event) {
     // Flush all work Items on this connection
     while (this.workItems.length > 0) {
       var workItem = this.workItems.shift();
-      // if(workItem.cb) workItem.cb(err);
       if (workItem.cb) workItem.cb(err);
     }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -111,6 +111,8 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
     this.cursorState.promoteLongs = topologyOptions.promoteLongs;
   } else if (typeof options.promoteLongs === 'boolean') {
     this.cursorState.promoteLongs = options.promoteLongs;
+  } else if (typeof options.session === 'object') {
+    this.cursorState.session = options.session;
   }
 
   // Add promoteValues to cursor state
@@ -286,6 +288,11 @@ Cursor.prototype._find = function(callback) {
   if (typeof self.cursorState.promoteBuffers === 'boolean') {
     queryOptions.promoteBuffers = self.cursorState.promoteBuffers;
   }
+
+  if (typeof self.cursorState.session === 'object') {
+    queryOptions.session = self.cursorState.session;
+  }
+
   // Write the initial command out
   self.server.s.pool.write(self.query, queryOptions, queryCallback);
 };

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -348,13 +348,7 @@ Cursor.prototype._killcursor = function(callback) {
   // Default pool
   var pool = this.server.s.pool;
   // Execute command
-  this.server.wireProtocolHandler.killCursor(
-    this.bson,
-    this.ns,
-    this.cursorState.cursorId,
-    pool,
-    callback
-  );
+  this.server.wireProtocolHandler.killCursor(this.bson, this.ns, this.cursorState, pool, callback);
 };
 
 /**

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -82,6 +82,8 @@ class ServerSession {
    * @param {*} sessionTimeoutMinutes
    */
   hasTimedOut(sessionTimeoutMinutes) {
+    // Take the difference of the lastUse timestamp and now, which will result in a value in
+    // milliseconds, and then convert milliseconds to minutes to compare to `sessionTimeoutMinutes`
     const idleTimeMinutes = Math.round(
       (((Date.now() - this.lastUse) % 86400000) % 3600000) / 60000
     );

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const Binary = require('mongodb-core').BSON.Binary,
+  uuidV4 = require('./utils').uuidV4;
+
+/**
+ *
+ */
+class ClientSession {
+  constructor(topology, options) {
+    if (topology == null) {
+      throw new Error('ClientSession requires a topology');
+    }
+
+    this.topology = topology;
+    this.options = options || {};
+    this.hasEnded = false;
+    this._serverSession = undefined; // TBD
+  }
+
+  /**
+   *
+   */
+  endSession(callback) {
+    if (this.hasEnded) {
+      return callback(null, null);
+    }
+
+    this.topology.command('admin.$cmd', { endSessions: 1, ids: [this.id] }, err => {
+      this.hasEnded = true;
+
+      if (err) return callback(err, null);
+      callback(null, null);
+    });
+  }
+}
+
+/**
+ *
+ */
+class ServerSession {
+  constructor() {
+    this.id = { id: new Binary(uuidV4(), Binary.SUBTYPE_UUID) };
+    this.lastUse = Date.now();
+  }
+
+  /**
+   *
+   * @param {*} sessionTimeoutMinutes
+   */
+  hasTimedOut(sessionTimeoutMinutes) {
+    const idleTimeMinutes = Math.round(
+      (((Date.now() - this.lastUse) % 86400000) % 3600000) / 60000
+    );
+
+    return idleTimeMinutes > sessionTimeoutMinutes;
+  }
+}
+
+/**
+ *
+ */
+class ServerSessionPool {
+  constructor(topology) {
+    this.topology = topology;
+    this.sessions = [];
+  }
+
+  /**
+   * @returns {ServerSession}
+   */
+  dequeue() {
+    const sessionTimeoutMinutes = this.topology.logicalSessionTimeoutMinutes;
+    while (this.sessions.length) {
+      const session = this.sessions.shift();
+      if (!session.hasTimedOut(sessionTimeoutMinutes)) {
+        return session;
+      }
+    }
+
+    return new ServerSession();
+  }
+
+  /**
+   *
+   * @param {*} session
+   */
+  enqueue(session) {
+    const sessionTimeoutMinutes = this.topology.logicalSessionTimeoutMinutes;
+    while (this.sessions.length) {
+      const session = this.sessions[this.sessions.length - 1];
+      if (session.hasTimedOut(sessionTimeoutMinutes)) {
+        this.sessions.pop();
+      } else {
+        break;
+      }
+    }
+
+    this.sessions.push(session);
+  }
+}
+
+module.exports = {
+  ClientSession: ClientSession,
+  ServerSession: ServerSession,
+  ServerSessionPool: ServerSessionPool
+};

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -49,13 +49,13 @@ class ClientSession {
       'admin.$cmd',
       { endSessions: 1, ids: [this.id] },
       { readPreference: ReadPreference.primaryPreferred },
-      err => {
+      () => {
         this.hasEnded = true;
 
         // release the server session back to the pool
         this.sessionPool.release(this.serverSession);
 
-        if (err) return callback(err, null);
+        // spec indicates that we should ignore all errors for `endSessions`
         callback(null, null);
       }
     );

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -12,6 +12,10 @@ class ClientSession {
       throw new Error('ClientSession requires a topology');
     }
 
+    if (sessionPool == null || !(sessionPool instanceof ServerSessionPool)) {
+      throw new Error('ClientSession requires a ServerSessionPool');
+    }
+
     this.topology = topology;
     this.sessionPool = sessionPool;
     this.hasEnded = false;
@@ -82,6 +86,10 @@ class ServerSession {
  */
 class ServerSessionPool {
   constructor(topology) {
+    if (topology == null) {
+      throw new Error('ServerSessionPool requires a topology');
+    }
+
     this.topology = topology;
     this.sessions = [];
   }

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -88,7 +88,7 @@ class ServerSession {
       (((Date.now() - this.lastUse) % 86400000) % 3600000) / 60000
     );
 
-    return idleTimeMinutes > sessionTimeoutMinutes;
+    return idleTimeMinutes > sessionTimeoutMinutes - 1;
   }
 }
 
@@ -135,7 +135,9 @@ class ServerSessionPool {
       }
     }
 
-    this.sessions.push(session);
+    if (!session.hasTimedOut(sessionTimeoutMinutes)) {
+      this.sessions.push(session);
+    }
   }
 }
 

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -15,7 +15,7 @@ class ClientSession {
     this.topology = topology;
     this.sessionPool = sessionPool;
     this.hasEnded = false;
-    this.serverSession = sessionPool.dequeue();
+    this.serverSession = sessionPool.acquire();
 
     options = options || {};
     if (typeof options.initialClusterTime !== 'undefined') {
@@ -41,7 +41,7 @@ class ClientSession {
       this.hasEnded = true;
 
       // release the server session back to the pool
-      this.sessionPool.enqueue(this.serverSession);
+      this.sessionPool.release(this.serverSession);
 
       if (err) return callback(err, null);
       callback(null, null);
@@ -89,7 +89,7 @@ class ServerSessionPool {
   /**
    * @returns {ServerSession}
    */
-  dequeue() {
+  acquire() {
     const sessionTimeoutMinutes = this.topology.logicalSessionTimeoutMinutes;
     while (this.sessions.length) {
       const session = this.sessions.shift();
@@ -105,7 +105,7 @@ class ServerSessionPool {
    *
    * @param {*} session
    */
-  enqueue(session) {
+  release(session) {
     const sessionTimeoutMinutes = this.topology.logicalSessionTimeoutMinutes;
     while (this.sessions.length) {
       const session = this.sessions[this.sessions.length - 1];

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const ReadPreference = require('./topologies/read_preference'),
-  Binary = require('mongodb-core').BSON.Binary,
+const retrieveBSON = require('./connection/utils').retrieveBSON,
+  ReadPreference = require('./topologies/read_preference'),
+  BSON = retrieveBSON(),
+  Binary = BSON.Binary,
   uuidV4 = require('./utils').uuidV4;
 
 /**

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -13,9 +13,13 @@ class ClientSession {
     }
 
     this.topology = topology;
-    this.options = options || {};
     this.hasEnded = false;
     this._serverSession = undefined; // TBD
+
+    options = options || {};
+    if (typeof options.initialClusterTime !== 'undefined') {
+      this.clusterTime = options.initialClusterTime;
+    }
   }
 
   /**
@@ -25,6 +29,12 @@ class ClientSession {
     if (this.hasEnded) {
       return callback(null, null);
     }
+
+    // TODO:
+    //   When connected to a sharded cluster the endSessions command
+    //   can be sent to any mongos. When connected to a replica set the
+    //   endSessions command MUST be sent to the primary if the primary
+    //   is available, otherwise it MUST be sent to any available secondary.
 
     this.topology.command('admin.$cmd', { endSessions: 1, ids: [this.id] }, err => {
       this.hasEnded = true;

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -921,6 +921,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 Mongos.prototype.insert = function(ns, ops, options, callback) {
@@ -953,6 +954,7 @@ Mongos.prototype.insert = function(ns, ops, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 Mongos.prototype.update = function(ns, ops, options, callback) {
@@ -985,6 +987,7 @@ Mongos.prototype.update = function(ns, ops, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 Mongos.prototype.remove = function(ns, ops, options, callback) {
@@ -1017,6 +1020,7 @@ Mongos.prototype.remove = function(ns, ops, options, callback) {
  * @param {Connection} [options.connection] Specify connection object to execute command against
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 Mongos.prototype.command = function(ns, cmd, options, callback) {
@@ -1060,6 +1064,7 @@ Mongos.prototype.command = function(ns, cmd, options, callback) {
  * @param {ReadPreference} [options.readPreference] Specify read preference if command supports it
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @returns {Cursor}
  */
 Mongos.prototype.cursor = function(ns, cmd, cursorOptions) {

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1198,6 +1198,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 ReplSet.prototype.insert = function(ns, ops, options, callback) {
@@ -1225,6 +1226,7 @@ ReplSet.prototype.insert = function(ns, ops, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 ReplSet.prototype.update = function(ns, ops, options, callback) {
@@ -1252,6 +1254,7 @@ ReplSet.prototype.update = function(ns, ops, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 ReplSet.prototype.remove = function(ns, ops, options, callback) {
@@ -1279,6 +1282,7 @@ ReplSet.prototype.remove = function(ns, ops, options, callback) {
  * @param {Connection} [options.connection] Specify connection object to execute command against
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 ReplSet.prototype.command = function(ns, cmd, options, callback) {
@@ -1520,6 +1524,7 @@ ReplSet.prototype.logout = function(dbName, callback) {
  * @param {ReadPreference} [options.readPreference] Specify read preference if command supports it
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @returns {Cursor}
  */
 ReplSet.prototype.cursor = function(ns, cmd, cursorOptions) {

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -639,6 +639,7 @@ function basicReadValidations(self, options) {
  * @param {Boolean} [options.checkKeys=false] Specify if the bson parser should validate keys.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {Boolean} [options.fullResult=false] Return the full envelope instead of just the result document.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 Server.prototype.command = function(ns, cmd, options, callback) {
@@ -709,6 +710,7 @@ Server.prototype.command = function(ns, cmd, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 Server.prototype.insert = function(ns, ops, options, callback) {
@@ -747,6 +749,7 @@ Server.prototype.insert = function(ns, ops, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 Server.prototype.update = function(ns, ops, options, callback) {
@@ -789,6 +792,7 @@ Server.prototype.update = function(ns, ops, options, callback) {
  * @param {object} [options.writeConcern={}] Write concern for the operation
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @param {opResultCallback} callback A callback function
  */
 Server.prototype.remove = function(ns, ops, options, callback) {
@@ -833,6 +837,7 @@ Server.prototype.remove = function(ns, ops, options, callback) {
  * @param {ReadPreference} [options.readPreference] Specify read preference if command supports it
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
+ * @param {ClientSession} [options.session=null] Session to use for the operation
  * @returns {Cursor}
  */
 Server.prototype.cursor = function(ns, cmd, cursorOptions) {

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -692,7 +692,8 @@ Server.prototype.command = function(ns, cmd, options, callback) {
     monitoring: typeof options.monitoring === 'boolean' ? options.monitoring : false,
     fullResult: typeof options.fullResult === 'boolean' ? options.fullResult : false,
     requestId: query.requestId,
-    socketTimeout: typeof options.socketTimeout === 'number' ? options.socketTimeout : null
+    socketTimeout: typeof options.socketTimeout === 'number' ? options.socketTimeout : null,
+    session: options.session || null
   };
 
   // Write the operation to the pool

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const crypto = require('crypto');
+
 /**
  * Copy the values of all enumerable own properties from one or more
  * source objects to a target object. It will return the target object.
  */
-var assign = Object.assign
+const assign = Object.assign
   ? Object.assign
   : function assign(target) {
       if (target === undefined || target === null) {
@@ -31,6 +33,14 @@ var assign = Object.assign
       return to;
     };
 
+const uuidV4 = () => {
+  const result = crypto.randomBytes(16);
+  result[6] = (result[6] & 0x0f) | 0x40;
+  result[8] = (result[8] & 0x3f) | 0x80;
+  return result;
+};
+
 module.exports = {
-  assign: assign
+  assign: assign,
+  uuidV4: uuidV4
 };

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -155,6 +155,10 @@ WireProtocol.prototype.getMore = function(
     queryOptions.promoteBuffers = cursorState.promoteBuffers;
   }
 
+  if (typeof cursorState.session === 'object') {
+    queryOptions.session = cursorState.session;
+  }
+
   // Write out the getMore command
   connection.write(getMore, queryOptions, queryCallback);
 };

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -49,6 +49,7 @@ var executeWrite = function(pool, bson, type, opsField, ns, ops, options, callba
 
   // Options object
   var opts = { command: true };
+  if (typeof options.session !== 'undefined') opts.session = options.session;
   var queryOptions = { checkKeys: false, numberToSkip: 0, numberToReturn: 1 };
   if (type === 'insert') queryOptions.checkKeys = true;
   if (typeof options.checkKeys === 'boolean') queryOptions.checkKeys = options.checkKeys;

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -106,8 +106,6 @@ WireProtocol.prototype.killCursor = function(bson, ns, cursorState, pool, callba
     } catch (err) {
       callback(err, null);
     }
-
-    return;
   }
 
   // Callback

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -255,6 +255,10 @@ WireProtocol.prototype.getMore = function(
     queryOptions.promoteBuffers = cursorState.promoteBuffers;
   }
 
+  if (typeof cursorState.session === 'object') {
+    queryOptions.session = cursorState.session;
+  }
+
   // Write out the getMore command
   connection.write(query, queryOptions, queryCallback);
 };

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -58,6 +58,7 @@ var executeWrite = function(pool, bson, type, opsField, ns, ops, options, callba
 
   // Options object
   var opts = { command: true };
+  if (typeof options.session !== 'undefined') opts.session = options.session;
   var queryOptions = { checkKeys: false, numberToSkip: 0, numberToReturn: 1 };
   if (type === 'insert') queryOptions.checkKeys = true;
   if (typeof options.checkKeys === 'boolean') queryOptions.checkKeys = options.checkKeys;

--- a/test/tests/unit/sessions_tests.js
+++ b/test/tests/unit/sessions_tests.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const Server = require('../../..').Server,
+  mock = require('../../mock'),
+  expect = require('chai').expect,
+  ServerSessionPool = require('../../../lib/sessions').ServerSessionPool,
+  ServerSession = require('../../../lib/sessions').ServerSession;
+
+let test = {};
+describe('Sessions', function() {
+  describe('ServerSessionPool', function() {
+    afterEach(() => {
+      test.client.destroy();
+      return mock.cleanup();
+    });
+
+    beforeEach(() => {
+      return mock
+        .createServer()
+        .then(server => {
+          test.server = server;
+          test.server.setMessageHandler(request => {
+            var doc = request.document;
+            if (doc.ismaster) {
+              request.reply(
+                Object.assign({}, mock.DEFAULT_ISMASTER, { logicalSessionTimeoutMinutes: 10 })
+              );
+            }
+          });
+        })
+        .then(() => {
+          test.client = new Server(test.server.address());
+
+          return new Promise((resolve, reject) => {
+            test.client.once('error', reject);
+            test.client.once('connect', resolve);
+            test.client.connect();
+          });
+        });
+    });
+
+    it('should create a new session if the pool is empty', {
+      metadata: { requires: { topology: 'single' } },
+
+      test: function(done) {
+        const pool = new ServerSessionPool(test.client);
+        expect(pool.sessions).to.have.length(0);
+        const session = pool.dequeue();
+        expect(session).to.exist;
+        expect(pool.sessions).to.have.length(0);
+        done();
+      }
+    });
+
+    it('should reuse sessions which have not timed out yet on dequeue', {
+      metadata: { requires: { topology: 'single' } },
+
+      test: function(done) {
+        const oldSession = new ServerSession();
+        const pool = new ServerSessionPool(test.client);
+        pool.sessions.push(oldSession);
+
+        const session = pool.dequeue();
+        expect(session).to.exist;
+        expect(session).to.eql(oldSession);
+
+        done();
+      }
+    });
+
+    it('should remove sessions which have timed out on dequeue, and return a fresh session', {
+      metadata: { requires: { topology: 'single' } },
+
+      test: function(done) {
+        const oldSession = new ServerSession();
+        oldSession.lastUse = new Date(Date.now() - 30 * 60 * 1000).getTime(); // add 30min
+
+        const pool = new ServerSessionPool(test.client);
+        pool.sessions.push(oldSession);
+
+        const session = pool.dequeue();
+        expect(session).to.exist;
+        expect(session).to.not.eql(oldSession);
+
+        done();
+      }
+    });
+
+    it('should remove sessions which have timed out on enqueue', {
+      metadata: { requires: { topology: 'single' } },
+
+      test: function(done) {
+        const newSession = new ServerSession();
+        const oldSessions = [new ServerSession(), new ServerSession()].map(session => {
+          session.lastUse = new Date(Date.now() - 30 * 60 * 1000).getTime(); // add 30min
+          return session;
+        });
+
+        const pool = new ServerSessionPool(test.client);
+        pool.sessions = pool.sessions.concat(oldSessions);
+
+        pool.enqueue(newSession);
+        expect(pool.sessions).to.have.length(1);
+        expect(pool.sessions[0]).to.eql(newSession);
+        done();
+      }
+    });
+  });
+});

--- a/test/tests/unit/sessions_tests.js
+++ b/test/tests/unit/sessions_tests.js
@@ -11,6 +11,23 @@ const Server = require('../../..').Server,
 let test = {};
 describe('Sessions', function() {
   describe('ClientSession', function() {
+    it('should throw errors with invalid parameters', {
+      metadata: { requires: { topology: 'single' } },
+      test: function() {
+        expect(() => {
+          new ClientSession();
+        }).to.throw(/ClientSession requires a topology/);
+
+        expect(() => {
+          new ClientSession({});
+        }).to.throw(/ClientSession requires a ServerSessionPool/);
+
+        expect(() => {
+          new ClientSession({}, {});
+        }).to.throw(/ClientSession requires a ServerSessionPool/);
+      }
+    });
+
     it('should default to `null` for `clusterTime`', {
       metadata: { requires: { topology: 'single' } },
       test: function() {
@@ -62,6 +79,15 @@ describe('Sessions', function() {
             test.client.connect();
           });
         });
+    });
+
+    it('should throw errors with invalid parameters', {
+      metadata: { requires: { topology: 'single' } },
+      test: function() {
+        expect(() => {
+          new ServerSessionPool();
+        }).to.throw(/ServerSessionPool requires a topology/);
+      }
     });
 
     it('should create a new session if the pool is empty', {

--- a/test/tests/unit/sessions_tests.js
+++ b/test/tests/unit/sessions_tests.js
@@ -69,14 +69,14 @@ describe('Sessions', function() {
       test: function(done) {
         const pool = new ServerSessionPool(test.client);
         expect(pool.sessions).to.have.length(0);
-        const session = pool.dequeue();
+        const session = pool.acquire();
         expect(session).to.exist;
         expect(pool.sessions).to.have.length(0);
         done();
       }
     });
 
-    it('should reuse sessions which have not timed out yet on dequeue', {
+    it('should reuse sessions which have not timed out yet on acquire', {
       metadata: { requires: { topology: 'single' } },
 
       test: function(done) {
@@ -84,7 +84,7 @@ describe('Sessions', function() {
         const pool = new ServerSessionPool(test.client);
         pool.sessions.push(oldSession);
 
-        const session = pool.dequeue();
+        const session = pool.acquire();
         expect(session).to.exist;
         expect(session).to.eql(oldSession);
 
@@ -92,7 +92,7 @@ describe('Sessions', function() {
       }
     });
 
-    it('should remove sessions which have timed out on dequeue, and return a fresh session', {
+    it('should remove sessions which have timed out on acquire, and return a fresh session', {
       metadata: { requires: { topology: 'single' } },
 
       test: function(done) {
@@ -102,7 +102,7 @@ describe('Sessions', function() {
         const pool = new ServerSessionPool(test.client);
         pool.sessions.push(oldSession);
 
-        const session = pool.dequeue();
+        const session = pool.acquire();
         expect(session).to.exist;
         expect(session).to.not.eql(oldSession);
 
@@ -110,7 +110,7 @@ describe('Sessions', function() {
       }
     });
 
-    it('should remove sessions which have timed out on enqueue', {
+    it('should remove sessions which have timed out on release', {
       metadata: { requires: { topology: 'single' } },
 
       test: function(done) {
@@ -123,7 +123,7 @@ describe('Sessions', function() {
         const pool = new ServerSessionPool(test.client);
         pool.sessions = pool.sessions.concat(oldSessions);
 
-        pool.enqueue(newSession);
+        pool.release(newSession);
         expect(pool.sessions).to.have.length(1);
         expect(pool.sessions[0]).to.eql(newSession);
         done();

--- a/test/tests/unit/sessions_tests.js
+++ b/test/tests/unit/sessions_tests.js
@@ -155,5 +155,19 @@ describe('Sessions', function() {
         done();
       }
     });
+
+    it('should not reintroduce a soon-to-expire session to the pool on release', {
+      metadata: { requires: { topology: 'single' } },
+
+      test: function(done) {
+        const session = new ServerSession();
+        session.lastUse = new Date(Date.now() - 9.5 * 60 * 1000).getTime(); // add 9.5min
+
+        const pool = new ServerSessionPool(test.client);
+        pool.release(session);
+        expect(pool.sessions).to.have.length(0);
+        done();
+      }
+    });
   });
 });

--- a/test/tests/unit/sessions_tests.js
+++ b/test/tests/unit/sessions_tests.js
@@ -15,7 +15,8 @@ describe('Sessions', function() {
       metadata: { requires: { topology: 'single' } },
       test: function() {
         const client = new Server();
-        const session = new ClientSession(client);
+        const sessionPool = new ServerSessionPool(client);
+        const session = new ClientSession(client, sessionPool);
         expect(session.clusterTime).to.not.exist;
       }
     });
@@ -25,7 +26,8 @@ describe('Sessions', function() {
       test: function() {
         const clusterTime = genClusterTime(Date.now());
         const client = new Server();
-        const session = new ClientSession(client, { initialClusterTime: clusterTime });
+        const sessionPool = new ServerSessionPool(client);
+        const session = new ClientSession(client, sessionPool, { initialClusterTime: clusterTime });
         expect(session.clusterTime).to.eql(clusterTime);
       }
     });

--- a/test/tests/unit/single/sessions_tests.js
+++ b/test/tests/unit/single/sessions_tests.js
@@ -276,7 +276,7 @@ describe('Sessions (Single)', function() {
       client.once('connect', () => {
         client.command('admin.$cmd', { ping: 1 }, { session: session }, err => {
           expect(err).to.not.exist;
-          expect(command.document.lsid).to.eql(session.id);
+          expect(command.lsid).to.eql(session.id);
           done();
         });
       });

--- a/test/tests/unit/single/sessions_tests.js
+++ b/test/tests/unit/single/sessions_tests.js
@@ -230,7 +230,8 @@ describe('Sessions (Single)', function() {
         sentIsMaster = true;
         request.reply(
           assign({}, mock.DEFAULT_ISMASTER, {
-            maxWireVersion: 6
+            maxWireVersion: 6,
+            logicalSessionTimeoutMinutes: 10
           })
         );
       });

--- a/test/tests/unit/single/sessions_tests.js
+++ b/test/tests/unit/single/sessions_tests.js
@@ -217,7 +217,7 @@ describe('Sessions (Single)', function() {
     }
   });
 
-  it.only('should return server sessions to the pool on `endSession`', {
+  it('should return server sessions to the pool on `endSession`', {
     metadata: { requires: { topology: 'single' } },
     test: function(done) {
       let sentIsMaster = false;


### PR DESCRIPTION
This is the first step in full support for driver sessions, implementing the `ClientSession` and `ServerSession` types, as well as the `ServerSessionPool`.  The rest of the behavior defined in the spec relates specifically to the porcelain layer ("Where does the pool live?", "Does the topology we're connecting to support sessions?", etc). 

Required reading: https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst

**NOTE:** This branch is based on the `cluster-time-gossiping` branch, so it might look a little big at first. Once #219 is merged this should reduce in size dramatically. 