### PR TITLE
re issue-220: remove _hiCache, not needed and fixes memory leak

### DIFF
--- a/lib/auth/scram.js
+++ b/lib/auth/scram.js
@@ -74,18 +74,9 @@ var xor = function(a, b) {
   return new Buffer(res);
 }
 
-// hiCache stores previous salt creations so it's not regenerated per-pool member
-var _hiCache = {};
-
 var hi = function(data, salt, iterations) {
-  var key = [data, salt.toString("base64"), iterations].join("_");
-  // check if we've already generated this salt
-  if (_hiCache[key] !== undefined) { return _hiCache[key] }
-  
-  // generate the salt and store it in the cache for the next worker
+  // generate the salt
   var data = crypto.pbkdf2Sync(data, salt, iterations, 20, "sha1");
-  _hiCache[key] = data;
-  
   return data;
 }
 


### PR DESCRIPTION
Remove `_hiCache` from `lib/auth/scram.js`.

`_hiCache` was never pruned, and in some environments grew without bound. This leaked memory, used more time to garbage collect, and increased call latencies. Testing showed that removing the cache had no adverse impact compared to mongodb-2.1.18, an older version of the mongo driver without _hiCache.