### PR TITLE
Fix race condition that leads to never-called query callbacks

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -700,6 +700,8 @@ Pool.prototype.auth = function(mechanism) {
     var connections = self.allConnections();
     // Allow nothing else to use the connections while we authenticate them
     self.availableConnections = [];
+    self.inUseConnections = [];
+    self.connectingConnections = [];
 
     var connectionsCount = connections.length;
     var error = null;
@@ -864,7 +866,7 @@ Pool.prototype.destroy = function(force) {
     while(self.queue.length > 0) {
       var workItem = self.queue.shift();
       if(typeof workItem.cb == 'function') {
-        workItem.cb(null, err);
+        workItem.cb(new MongoError('discarding item from force-destroyed pool'));
       }
     }
 
@@ -1300,6 +1302,7 @@ function _execute(self) {
           }
 
           if(writeSuccessful && workItem.immediateRelease && self.authenticating) {
+            removeConnection(self, connection);
             self.nonAuthenticatedConnections.push(connection);
           } else if(writeSuccessful === false) {
             // If write not successful put back on queue


### PR DESCRIPTION
We've been investigating user reports that Meteor's oplog tailing operation can
stall.  I've tracked it down to a race condition in the Node Mongo driver.

There honestly might be more than one underlying bug, but this one appears to be
the culprit at least some of the time.

My understanding of the issue: It is possible for Pool's availableConnections
list to accidentally contain duplicates. This then leads to the socketCount() in
connectionFailureHandler to stay at 1 even after the last connection has been
removed, because of its duplicate. This means that the server and pool do not
got destroyed.

This has a couple of effects.

One of them is that, if messages end up in the 'queue' of the pool, they will
never trigger the NODE-1039 fix (which is itself buggy due to referencing a
nonexistent variable).

Another effect is that the `self.topology.isConnected` check in cursor.js's
`nextFunction` can return true even when we actually closed our last connection
to a server.  That means that the cursor fails to take advantage of the
disconnectHandler and instead tries to send the query immediately on the server
which is actually closed but whose state is somewhat corrupted.

In practice the latter seems to be the most directly applicable bug, because
fixing this issue means that the messages in question never end up on the Pool's
`queue` in the first place.

How does this availableConnections duplicate situation occur? Honestly there may
be multiple ways, as the list is manipulated in a bunch of places with no
duplicate checks.

The one I found is: if there is an in-flight replset `pingServer` ismaster
command when MongoClient calls Pool.prototype.auth, then its connection will be in
`inUseConnections` rather than `availableConnections`.
`authenticateLiveConnections` will **not** clear that list, and so when its
response comes back, `authenticateStragglers` will move the connection from
`inUseConnections` to `availableConnections`. Then when
`authenticateLiveConnections` has successfully authed the connection, its concat
will get the connection in there twice.

See https://github.com/glasser/mongo-driver-race-condition for details on how to
reproduce.

Fixes NODE-1153.