### PR TITLE
cache the ScramSHA1 salted passwords, capping the cache at 200 entries

### DIFF
--- a/lib/auth/scram.js
+++ b/lib/auth/scram.js
@@ -74,9 +74,22 @@ var xor = function(a, b) {
   return new Buffer(res);
 }
 
+var _hiCache = {}, _hiCacheCount = 0;
+var _hiCachePurge = function() { _hiCache = {}; _hiCacheCount = 0; }
+
 var hi = function(data, salt, iterations) {
+  // omit the work if already generated
+  var key = data + '_' + salt.toString('base64') + '_' + iterations;
+  if (_hiCache[key] !== undefined) return _hiCache[key];
+
   // generate the salt
   var data = crypto.pbkdf2Sync(data, salt, iterations, 20, "sha1");
+
+  // cache a copy to speed up the next lookup, but prevent unbounded cache growth
+  if (_hiCacheCount >= 200) _hiCachePurge();
+  _hiCache[key] = data;
+  _hiCacheCount += 1;
+
   return data;
 }
 

--- a/lib/auth/scram.js
+++ b/lib/auth/scram.js
@@ -83,14 +83,14 @@ var hi = function(data, salt, iterations) {
   if (_hiCache[key] !== undefined) return _hiCache[key];
 
   // generate the salt
-  var data = crypto.pbkdf2Sync(data, salt, iterations, 20, "sha1");
+  var saltedData = crypto.pbkdf2Sync(data, salt, iterations, 20, "sha1");
 
   // cache a copy to speed up the next lookup, but prevent unbounded cache growth
   if (_hiCacheCount >= 200) _hiCachePurge();
   _hiCache[key] = data;
   _hiCacheCount += 1;
 
-  return data;
+  return saltedData;
 }
 
 /**


### PR DESCRIPTION
restores the`_hiCache` functionality, but without the unbounded cache growth