### PR TITLE
fix(auth-scram): fixing an issue where the unsalted password is being cached

### DIFF
--- a/lib/auth/scram.js
+++ b/lib/auth/scram.js
@@ -87,7 +87,7 @@ var hi = function(data, salt, iterations) {
 
   // cache a copy to speed up the next lookup, but prevent unbounded cache growth
   if (_hiCacheCount >= 200) _hiCachePurge();
-  _hiCache[key] = data;
+  _hiCache[key] = saltedData;
   _hiCacheCount += 1;
 
   return saltedData;


### PR DESCRIPTION
With 2.1.16, only the first auth will succeed, because subsequent calls with the same password will return the unsalted one.