### PR TITLE
fix(connection): default `family` to undefined rather than 4

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -23,7 +23,7 @@ var connections = {};
  * @class
  * @param {string} options.host The server host
  * @param {number} options.port The server port
- * @param {number} [options.family=4] Version of IP stack. Defaults to 4.
+ * @param {number} [options.family=null] IP version for DNS lookup, passed down to Node's [`dns.lookup()` function](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback). If set to `6`, will only look for ipv6 addresses.
  * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
  * @param {number} [options.keepAliveInitialDelay=300000] Initial delay before TCP keep alive enabled
  * @param {boolean} [options.noDelay=true] TCP Connection no delay
@@ -74,7 +74,7 @@ var Connection = function(messageHandler, options) {
   // Default options
   this.port = options.port || 27017;
   this.host = options.host || 'localhost';
-  this.family = typeof options.family == 'number' ? options.family : 4;
+  this.family = typeof options.family == 'number' ? options.family : void 0;
   this.keepAlive = typeof options.keepAlive == 'boolean' ? options.keepAlive : true;
   this.keepAliveInitialDelay = typeof options.keepAliveInitialDelay == 'number' 
     ? options.keepAliveInitialDelay : 300000;
@@ -406,9 +406,15 @@ Connection.prototype.connect = function(_options) {
   }
 
   // Create new connection instance
-  var connection_options = self.domainSocket
-    ? {path: self.host}
-    : {port: self.port, host: self.host, family: self.family};
+  var connection_options;
+  if (self.domainSocket) {
+    connection_options = {path: self.host};
+  } else {
+    connection_options = {port: self.port, host: self.host};
+    if (self.family !== void 0) {
+      connection_options.family = self.family; 
+    }
+  }
   self.connection = net.createConnection(connection_options);
 
   // Set the options for the connection


### PR DESCRIPTION
Upon closer inspection, #183 was actually very much backwards breaking and should not have been merged. This issue causes https://github.com/Automattic/mongoose/issues/5760 via https://github.com/Automattic/mongoose/commit/93e771ce5678c20da3a8dd08a4b77de8a1380446 .

The problem with #183 is that [`net.createConnection()`](https://nodejs.org/api/net.html) calls [`dns.lookup()`](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback) with the `family` option always set. If the `family` option is not set, `dns.lookup()` will return both ipv4 and ipv6 addresses, but since mongodb-core always sets `family` now, the driver can only connect to ipv4 or ipv6 depending on the value of `family`. In particular, this means that any user that was connecting to an ipv6 address now **must** specify `family: 6` in porcelain layer >= 2.2.28 and mongoose >= 4.11.6 in order to successfully connect, whereas they didn't have to before.