### PR TITLE
fix(utils): don't throw if no snappy

### DIFF
--- a/lib/connection/utils.js
+++ b/lib/connection/utils.js
@@ -89,7 +89,10 @@ var noSnappyWarning = function() {
 
 // Facilitate loading Snappy optionally
 var retrieveSnappy = function() {
-  var snappy = require_optional('snappy');
+  var snappy = null;
+  try {
+    snappy = require_optional('snappy');
+  } catch (error) {} // eslint-disable-line
   if (!snappy) {
     snappy = {
       compress: noSnappyWarning,


### PR DESCRIPTION
Getting the following error when running mongoose against the 3.0 driver branch:

```javascript
> mongoose@5.0.0-pre test /home/val/Workspace/MongoDB/mongoose
> mocha test/*.test.js test/**/*.test.js

/home/val/Workspace/MongoDB/mongoose/node_modules/require_optional/index.js:56
    throw new Error(f('no optional dependency [%s] defined in peerOptionalDependencies in any package.json', parts[0]));
    ^

Error: no optional dependency [snappy] defined in peerOptionalDependencies in any package.json
    at find_package_json_with_name (/home/val/Workspace/MongoDB/mongoose/node_modules/require_optional/index.js:56:11)
    at require_optional (/home/val/Workspace/MongoDB/mongoose/node_modules/require_optional/index.js:69:13)
    at Object.retrieveSnappy (/home/val/Workspace/MongoDB/mongoose/node_modules/mongodb-core/lib/connection/utils.js:92:16)
    at Object.<anonymous> (/home/val/Workspace/MongoDB/mongoose/node_modules/mongodb-core/lib/wireprotocol/compression.js:3:45)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/val/Workspace/MongoDB/mongoose/node_modules/mongodb-core/lib/connection/connection.js:11:16)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
```

Looks like `require_optional()` throws an error if no `package.json` has snappy, this fix is enough to at least make the tests start running. 