### PR TITLE
fix(cursor): check for autoReconnect option only for single server

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -535,7 +535,9 @@ var nextFunction = function(self, callback) {
     // Topology is not connected, save the call in the provided store to be
     // Executed at some point when the handler deems it's reconnected
     if(!self.topology.isConnected(self.options)) {
-      if (!self.topology.s.options.reconnect) {
+      // Only need this for single server, because repl sets and mongos
+      // will always continue trying to reconnect
+      if (self.topology._type === 'server' && !self.topology.s.options.reconnect) {
         // Reconnect is disabled, so we'll never reconnect
         return callback(new MongoError('no connection available'));
       }


### PR DESCRIPTION
I made a mistake in https://github.com/mongodb-js/mongodb-core/pull/215 that is likely causing Automattic/mongoose#5794: `reconnect` isn't a topology option for replica sets or mongos, so my change could cause cursors to incorrectly think that the topology will never reconnect. I suspect this issue will be fixed if we just limit the "fail fast if `autoReconnect` disabled and topology is disconnected" to just single servers.