### PR TITLE
feat(replset): more verbose replica set errors emission 

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -648,14 +648,14 @@ function topologyMonitor(self, options) {
 
       if (!self.s.replicaSetState.hasPrimary() && !self.s.options.secondaryOnlyConnectionAllowed) {
         if (err) return self.emit('error', err);
-        self.emit('error', new MongoError('no primary found in replicaset'));
+        self.emit('error', new MongoError('no primary found in replicaset or invalid replica set name'));
         return self.destroy({ force: true });
       } else if (
         !self.s.replicaSetState.hasSecondary() &&
         self.s.options.secondaryOnlyConnectionAllowed
       ) {
         if (err) return self.emit('error', err);
-        self.emit('error', new MongoError('no secondary found in replicaset'));
+        self.emit('error', new MongoError('no secondary found in replicaset or invalid replica set name'));
         return self.destroy({ force: true });
       }
 


### PR DESCRIPTION
Port of #231 to 3.0.0.
When a replica set topology has an invalid name, core emits an error
stating that no primary or secondary found in the replica set, which can
cause some user confusion. This simply expands the language to include
that the name may be invalid to help with debugging.