### PR TITLE
feat(causal-consistency): add support for causally consistent reads

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -1166,6 +1166,7 @@ Pool.prototype.write = function(commands, options, cb) {
     }
 
     if (operation.session) {
+      // TODO: reenable when sessions development is complete
       // if (operation.session.topology !== this.topology) {
       //   return cb(
       //     new MongoError('Sessions may only be used with the client they were created from')

--- a/test/mock/index.js
+++ b/test/mock/index.js
@@ -52,6 +52,11 @@ const DEFAULT_ISMASTER = {
   ok: 1
 };
 
+const DEFAULT_ISMASTER_36 = Object.assign({}, DEFAULT_ISMASTER, {
+  maxWireVersion: 6,
+  logicalSessionTimeoutMinutes: 10
+});
+
 /*
  * Main module
  */
@@ -67,5 +72,6 @@ module.exports = {
   },
 
   cleanup: cleanup,
-  DEFAULT_ISMASTER: DEFAULT_ISMASTER
+  DEFAULT_ISMASTER: DEFAULT_ISMASTER,
+  DEFAULT_ISMASTER_36: DEFAULT_ISMASTER_36
 };

--- a/test/tests/unit/common.js
+++ b/test/tests/unit/common.js
@@ -91,6 +91,13 @@ class ReplSetFixture {
   }
 }
 
+/**
+ * Creates a cluster time for use in unit testing cluster time gossiping and
+ * causal consistency.
+ *
+ * @param {Number} time the logical time
+ * @returns a cluster time according to the driver sessions specification
+ */
 function genClusterTime(time) {
   return {
     clusterTime: new Timestamp(time),


### PR DESCRIPTION
Version 3.6 of the server introduces support for [causal consistency of reads](https://github.com/mongodb/specifications/blob/master/source/causal-consistency/causal-consistency.rst), this pull request adds support for this feature to the core layer of the driver.




