### PR TITLE
test(pool): remove .only in test

### DIFF
--- a/test/tests/functional/pool_tests.js
+++ b/test/tests/functional/pool_tests.js
@@ -39,7 +39,7 @@ describe('Pool tests', function() {
     }
   });
 
-  it.only('Should only listen on connect once', {
+  it('Should only listen on connect once', {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {


### PR DESCRIPTION
This removes a `.only` in the pool tests (causing it to run just one test) that got left in changes via in #235 🍍 

