### PR TITLE
refactor(endSessions): add helper for endSessions on topologies

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -11,7 +11,8 @@ var inherits = require('util').inherits,
   clone = require('./shared').clone,
   diff = require('./shared').diff,
   cloneOptions = require('./shared').cloneOptions,
-  createClientInfo = require('./shared').createClientInfo;
+  createClientInfo = require('./shared').createClientInfo,
+  SessionMixins = require('./shared').SessionMixins;
 
 var BSON = retrieveBSON();
 
@@ -237,6 +238,7 @@ var Mongos = function(seedlist, options) {
 };
 
 inherits(Mongos, EventEmitter);
+Object.assign(Mongos.prototype, SessionMixins);
 
 Object.defineProperty(Mongos.prototype, 'type', {
   enumerable: true,

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -13,7 +13,8 @@ var inherits = require('util').inherits,
   clone = require('./shared').clone,
   Timeout = require('./shared').Timeout,
   Interval = require('./shared').Interval,
-  createClientInfo = require('./shared').createClientInfo;
+  createClientInfo = require('./shared').createClientInfo,
+  SessionMixins = require('./shared').SessionMixins;
 
 var MongoCR = require('../auth/mongocr'),
   X509 = require('../auth/x509'),
@@ -257,6 +258,7 @@ var ReplSet = function(seedlist, options) {
 };
 
 inherits(ReplSet, EventEmitter);
+Object.assign(ReplSet.prototype, SessionMixins);
 
 Object.defineProperty(ReplSet.prototype, 'type', {
   enumerable: true,

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -18,7 +18,8 @@ var inherits = require('util').inherits,
   assign = require('../utils').assign,
   createClientInfo = require('./shared').createClientInfo,
   createCompressionInfo = require('./shared').createCompressionInfo,
-  resolveClusterTime = require('./shared').resolveClusterTime;
+  resolveClusterTime = require('./shared').resolveClusterTime,
+  SessionMixins = require('./shared').SessionMixins;
 
 // Used for filtering out fields for loggin
 var debugFields = [
@@ -188,6 +189,7 @@ var Server = function(options) {
 };
 
 inherits(Server, EventEmitter);
+Object.assign(Server.prototype, SessionMixins);
 
 Object.defineProperty(Server.prototype, 'type', {
   enumerable: true,
@@ -566,7 +568,7 @@ Server.prototype.connect = function(options) {
  * Get the server description
  * @method
  * @return {object}
-*/
+ */
 Server.prototype.getDescription = function() {
   var ismaster = this.ismaster || {};
   var description = {


### PR DESCRIPTION
 * This allows us to generically end a number of sessions with a
   single command, mixed into all three supported topologies.

 * We also support a `skipCommand` option on the session's
   `endSession` so that we can clear the data stored in these.

 * Finally, ClientSession is now an EventEmitter, so we can track
   them in a collection on the top level MongoClient and clean
   up when appropriate.