### PR TITLE
fix(connection): accept incoming missed ssl options from mongo-native-driver

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -105,6 +105,8 @@ var Connection = function(messageHandler, options) {
   this.cert = options.cert || null;
   this.key = options.key || null;
   this.passphrase = options.passphrase || null;
+  this.ciphers = options.ciphers || null;
+  this.ecdhCurve = options.ecdhCurve || null;
   this.ssl = typeof options.ssl == 'boolean' ? options.ssl : false;
   this.rejectUnauthorized = typeof options.rejectUnauthorized == 'boolean' ? options.rejectUnauthorized : true;
   this.checkServerIdentity = typeof options.checkServerIdentity == 'boolean'


### PR DESCRIPTION
Hi, this is second part of PRs. The first is #243.
This will allow to `mongo-native-driver` to send `ciphers` and `ecdhCurve` options to `mongodb-core`

One moment I'm not sure:
[here](https://github.com/mongodb-js/mongodb-core/blob/2.0/lib/connection/connection.js#L431), then I've tested with mongos and servers these two options already was in `sslOptions` object, so I leave this place.

Related with #245