### PR TITLE
Artificial _called property set on Timeout instance...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 os: linux
 language: node_js
 node_js:
+  - "0.10"
+  - "0.12"
   - "4"
   - "6"
   - "8"

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -217,7 +217,8 @@ function Timeout(fn, time) {
 
   this.start = function () {
     if (!this.isRunning()) {
-      timer = setTimeout(function() { fn(); if (timer !== false) { timer._called = true; } }, time);
+      // The artificial _called is set here for compatibility with node.js 0.10.x/0.12.x versions
+      timer = setTimeout(function() { fn(); if (timer !== false && timer._called === undefined) { timer._called = true; } }, time);
     }
     return this;
   };

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -217,7 +217,7 @@ function Timeout(fn, time) {
 
   this.start = function () {
     if (!this.isRunning()) {
-      timer = setTimeout(fn, time);
+      timer = setTimeout(function() { fn(); if (timer !== false) { timer._called = true; } }, time);
     }
     return this;
   };

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -217,8 +217,13 @@ function Timeout(fn, time) {
 
   this.start = function () {
     if (!this.isRunning()) {
-      // The artificial _called is set here for compatibility with node.js 0.10.x/0.12.x versions
-      timer = setTimeout(function() { fn(); if (timer !== false && timer._called === undefined) { timer._called = true; } }, time);
+      timer = setTimeout(function() {
+        fn();
+        if (timer && timer._called === undefined) {
+          // The artificial _called is set here for compatibility with node.js 0.10.x/0.12.x versions
+          timer._called = true;
+        }
+      }, time);
     }
     return this;
   };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "require_optional": "~1.0.0"
   },
   "devDependencies": {
+    "request": "2.65.0",
     "co": "^4.5.4",
     "coveralls": "^2.11.6",
     "es6-promise": "^3.0.2",

--- a/test/runner.js
+++ b/test/runner.js
@@ -196,38 +196,47 @@ var runner = new Runner({
   , failFast: true
 });
 
-var testFiles = [
-  // Functional tests
-  '/test/tests/functional/server_tests.js',
-  '/test/tests/functional/cursor_tests.js',
-  '/test/tests/functional/extend_cursor_tests.js',
-  '/test/tests/functional/undefined_tests.js',
-  '/test/tests/functional/tailable_cursor_tests.js',
-  '/test/tests/functional/error_tests.js',
-  '/test/tests/functional/operations_tests.js',
-  '/test/tests/functional/operation_example_tests.js',
-  '/test/tests/functional/basic_single_server_auth_tests.js',
-  '/test/tests/functional/basic_replset_server_auth_tests.js',
-  '/test/tests/functional/replset_tests.js',
-  // Replicaset monitoring tests
-  '/test/tests/functional/monitoring_tests.js',
-  // Replicaset SDAM tests
-  '/test/tests/functional/replset_state_tests.js',
-  // Replicaset Server selection tests
-  '/test/tests/functional/replset_server_selection_tests.js',
-  '/test/tests/functional/mongos_server_selection_tests.js',
-  // Replicaset max staleness tests
-  '/test/tests/functional/max_staleness_tests.js',
-  // Client Metadata test
-  '/test/tests/functional/client_metadata_tests.js'
-]
+var testFiles = [];
 
-// Check if we support es6 generators
 try {
   eval("(function *(){})");
 
   // Functional tests
-  testFiles.push('/test/tests/functional/pool_tests.js');
+  testFiles.push('/test/tests/functional/pool_tests.js')
+} catch(err) {}
+
+// Functional tests
+testFiles.push('/test/tests/functional/server_tests.js');
+testFiles.push('/test/tests/functional/cursor_tests.js');
+testFiles.push('/test/tests/functional/extend_cursor_tests.js');
+testFiles.push('/test/tests/functional/undefined_tests.js');
+testFiles.push('/test/tests/functional/tailable_cursor_tests.js');
+testFiles.push('/test/tests/functional/error_tests.js');
+testFiles.push('/test/tests/functional/operations_tests.js');
+testFiles.push('/test/tests/functional/operation_example_tests.js');
+testFiles.push('/test/tests/functional/basic_single_server_auth_tests.js');
+testFiles.push('/test/tests/functional/basic_replset_server_auth_tests.js');
+testFiles.push('/test/tests/functional/replset_tests.js');
+
+// Replicaset monitoring tests
+testFiles.push('/test/tests/functional/monitoring_tests.js');
+
+// Replicaset SDAM tests
+testFiles.push('/test/tests/functional/replset_state_tests.js');
+
+// Replicaset Server selection tests
+testFiles.push('/test/tests/functional/replset_server_selection_tests.js');
+testFiles.push('/test/tests/functional/mongos_server_selection_tests.js');
+
+// Replicaset max staleness tests
+testFiles.push('/test/tests/functional/max_staleness_tests.js');
+
+// Client Metadata test
+testFiles.push('/test/tests/functional/client_metadata_tests.js');
+
+// Check if we support es6 generators
+try {
+  eval("(function *(){})");
 
   // Single server Mock Tests
   testFiles.push('/test/tests/functional/single_mocks/timeout_tests.js');

--- a/test/runner.js
+++ b/test/runner.js
@@ -198,7 +198,6 @@ var runner = new Runner({
 
 var testFiles = [
   // Functional tests
-  '/test/tests/functional/pool_tests.js',
   '/test/tests/functional/server_tests.js',
   '/test/tests/functional/cursor_tests.js',
   '/test/tests/functional/extend_cursor_tests.js',
@@ -210,6 +209,8 @@ var testFiles = [
   '/test/tests/functional/basic_single_server_auth_tests.js',
   '/test/tests/functional/basic_replset_server_auth_tests.js',
   '/test/tests/functional/replset_tests.js',
+  // Replicaset monitoring tests
+  '/test/tests/functional/monitoring_tests.js',
   // Replicaset SDAM tests
   '/test/tests/functional/replset_state_tests.js',
   // Replicaset Server selection tests
@@ -224,6 +225,9 @@ var testFiles = [
 // Check if we support es6 generators
 try {
   eval("(function *(){})");
+
+  // Functional tests
+  testFiles.push('/test/tests/functional/pool_tests.js');
 
   // Single server Mock Tests
   testFiles.push('/test/tests/functional/single_mocks/timeout_tests.js');

--- a/test/tests/functional/monitoring_tests.js
+++ b/test/tests/functional/monitoring_tests.js
@@ -1,0 +1,147 @@
+"use strict";
+var assign = require('../../../lib/utils').assign;
+
+var timeoutPromise = function(timeout) {
+  return new Promise(function(resolve, reject) {
+    setTimeout(function() {
+      resolve();
+    }, timeout);
+  });
+}
+
+exports['Should not create excessive amount of Timeouts in intervalIds array'] = {
+  metadata: {
+    requires: {
+      // generators: true,
+      topology: "single"
+    }
+  },
+
+  test: function(configuration, test) {
+    var ReplSet = configuration.require.ReplSet,
+      ObjectId = configuration.require.BSON.ObjectId,
+      // Connection = require('../../../lib/connection/connection'),
+      // co = require('co'),
+      mockupdb = require('../../mock');
+
+    // Contain mock server
+    var primaryServer = null;
+    var firstSecondaryServer = null;
+    var secondSecondaryServer = null;
+    var running = true;
+    var electionIds = [new ObjectId(), new ObjectId()];
+    // Current index for the ismaster
+    var currentIsMasterState = 0;
+    // Primary stop responding
+    var stopRespondingPrimary = false;
+
+    // Default message fields
+    var defaultFields = {
+      "setName": "rs", "setVersion": 1, "electionId": electionIds[currentIsMasterState],
+      "maxBsonObjectSize" : 16777216, "maxMessageSizeBytes" : 48000000,
+      "maxWriteBatchSize" : 1000, "localTime" : new Date(), "maxWireVersion" : 3,
+      "minWireVersion" : 0, "ok" : 1, "hosts": ["localhost:32000", "localhost:32001", "localhost:32002"]
+    }
+
+    // Primary server states
+    var primary = [assign({}, defaultFields, {
+      "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000"
+    }), assign({}, defaultFields, {
+      "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32001"
+    })];
+
+    // Primary server states
+    var firstSecondary = [assign({}, defaultFields, {
+      "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000"
+    }), assign({}, defaultFields, {
+      "ismaster":true, "secondary":false, "me": "localhost:32001", "primary": "localhost:32001"
+    })];
+
+    // Primary server states
+    var secondSecondary = [assign({}, defaultFields, {
+      "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000"
+    }), assign({}, defaultFields, {
+      "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32001"
+    })];
+
+    // Boot the mock
+    Promise.all([
+      mockupdb.createServer(32000, 'localhost').then(function(server) { primaryServer = server; }),
+      mockupdb.createServer(32001, 'localhost').then(function(server) { firstSecondaryServer = server; }),
+      mockupdb.createServer(32002, 'localhost').then(function(server) { secondSecondaryServer = server; })
+    ]).then(function() {
+      function runInfinitely(fn) {
+        return primaryServer.receive().then(function(request) {
+          if (fn(request)) { return runInfinitely(fn); }
+        });
+      }
+
+      // Primary state machine
+      runInfinitely(function(request) {
+        var doc = request.document;
+
+        if(doc.ismaster && currentIsMasterState == 0) {
+          request.reply(primary[currentIsMasterState]);
+        }
+        return running;
+      })
+
+      // First secondary state machine
+      runInfinitely(function(request) {
+        var doc = request.document;
+
+        if(doc.ismaster) {
+          request.reply(firstSecondary[currentIsMasterState]);
+        }
+        return running;
+      });
+
+      // Second secondary state machine
+      runInfinitely(function(request) {
+        var doc = request.document;
+
+        if(doc.ismaster) {
+          request.reply(secondSecondary[currentIsMasterState]);
+        }
+        return running;
+      });
+
+    });
+
+    // Attempt to connect
+    var server = new ReplSet([
+      { host: 'localhost', port: 32000 },
+      { host: 'localhost', port: 32001 },
+      { host: 'localhost', port: 32002 }], {
+        setName: 'rs',
+        connectionTimeout: 5000,
+        socketTimeout: 60000,
+        haInterval: 200,
+        size: 1
+    });
+
+    // Add event listeners
+    server.on('connect', function(_server) {
+      setTimeout(function() {
+        console.dir("Total amount of Timeout instances running: " + _server.intervalIds.length);
+        test.ok(_server.intervalIds.length === 3);
+
+        // Destroy mock
+        primaryServer.destroy();
+        firstSecondaryServer.destroy();
+        secondSecondaryServer.destroy();
+        server.destroy();
+        running = false;
+
+        test.equal(0, _server.intervalIds.length);
+
+        test.done();
+      }, 5000);
+    });
+
+    // Gives proxies a chance to boot up
+    setTimeout(function() {
+      server.connect();
+    }, 100)
+  }
+}

--- a/test/tests/functional/pool_tests.js
+++ b/test/tests/functional/pool_tests.js
@@ -60,10 +60,10 @@ exports['Should only listen on connect once'] = {
 
     // Add event listeners
     pool.on('connect', function(_pool) {
-      process.nextTick(() => {
+      process.nextTick(function() {
         // Now that we are in next tick, connection should still exist, but there
         // should be no connect listeners
-        test.equal(0, connection.connection.listenerCount('connect'));
+        test.equal(0, connection.connection.listeners('connect').length);
         test.equal(1, pool.allConnections().length);
 
         _pool.destroy();
@@ -82,7 +82,7 @@ exports['Should only listen on connect once'] = {
 
     test.equal(1, pool.allConnections().length);
     connection = pool.allConnections()[0];
-    test.equal(1, connection.connection.listenerCount('connect'));
+    test.equal(1, connection.connection.listeners('connect').length);
   }
 }
 

--- a/test/tests/functional/rs_mocks/maintanance_mode_tests.js
+++ b/test/tests/functional/rs_mocks/maintanance_mode_tests.js
@@ -51,7 +51,7 @@ exports['Successfully detect server in maintanance mode'] = {
     // Primary server states
     var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), { "ismaster" : true,
+    }), {
       "ismaster":false, "secondary":false, "arbiterOnly": false, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     }];
 


### PR DESCRIPTION
... to have Timeout.isRunning() work properly for legacy node.js versions. Resolves mongodb-js/mongodb-core#247.

Fixing Timeout.isRunning was probably the best way to solve the issue and fit into the initial idea behind Timeout class.

Also returned back 0.10 and 0.12 targets for Travis. For that reason the 'request' lib has been fixed to @2.65.0 version in dev deps and added tests for the memory leak issue.

It does not seem to be reasonable to have these legacy targets to be turned off simply because of Hawk semver. That move has eventually played a dramatic role in hidding of the Timeout._called absence for v0.12 which was causing memory leak.