### PR TITLE
feat(retryable-writes): add basic support for retryable writes to mongodb-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       env: MONGODB_VERSION=3.4.x
     - stage: tests
       node_js: 4
-      env: MONGODB_VERSION=3.5.x
+      env: MONGODB_VERSION=3.6.0-rc5
 
     - stage: tests
       node_js: 6

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -110,6 +110,7 @@ class ServerSession {
   constructor() {
     this.id = { id: new Binary(uuidV4(), Binary.SUBTYPE_UUID) };
     this.lastUse = Date.now();
+    this.txnNumber = 0;
   }
 
   /**

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -15,7 +15,7 @@ const inherits = require('util').inherits,
   createClientInfo = require('./shared').createClientInfo,
   SessionMixins = require('./shared').SessionMixins,
   isRetryableWritesSupported = require('./shared').isRetryableWritesSupported,
-  txnNumber = require('./shared').txnNumber;
+  getNextTransactionNumber = require('./shared').getNextTransactionNumber;
 
 const BSON = retrieveBSON();
 
@@ -896,7 +896,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
   }
 
   // increment and assign txnNumber
-  options.txnNumber = txnNumber(options.session);
+  options.txnNumber = getNextTransactionNumber(options.session);
 
   server[op](ns, ops, options, (err, result) => {
     if (!err) return callback(null, result);

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -900,7 +900,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
 
   server[op](ns, ops, options, (err, result) => {
     if (!err) return callback(null, result);
-    if (err instanceof errors.MongoNetworkError) {
+    if (!(err instanceof errors.MongoNetworkError)) {
       return callback(err);
     }
 
@@ -908,7 +908,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
     server = pickProxy(self);
 
     // No server found error out with original error
-    if (!server) {
+    if (!server || !isRetryableWritesSupported(server)) {
       return callback(err);
     }
 

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -927,6 +927,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session=null] Session to use for the operation
+ * @param {boolean} [options.retryWrites] Enable retryable writes for this operation
  * @param {opResultCallback} callback A callback function
  */
 Mongos.prototype.insert = function(ns, ops, options, callback) {
@@ -960,6 +961,7 @@ Mongos.prototype.insert = function(ns, ops, options, callback) {
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session=null] Session to use for the operation
+ * @param {boolean} [options.retryWrites] Enable retryable writes for this operation
  * @param {opResultCallback} callback A callback function
  */
 Mongos.prototype.update = function(ns, ops, options, callback) {
@@ -993,6 +995,7 @@ Mongos.prototype.update = function(ns, ops, options, callback) {
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session=null] Session to use for the operation
+ * @param {boolean} [options.retryWrites] Enable retryable writes for this operation
  * @param {opResultCallback} callback A callback function
  */
 Mongos.prototype.remove = function(ns, ops, options, callback) {

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -900,7 +900,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
 
   server[op](ns, ops, options, (err, result) => {
     if (!err) return callback(null, result);
-    if (!(err instanceof errors.MongoNetworkError)) {
+    if (!(err instanceof errors.MongoNetworkError) && !err.message.match(/not master/)) {
       return callback(err);
     }
 

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -912,9 +912,6 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
       return callback(err);
     }
 
-    // increment and assign txnNumber
-    options.txnNumber = txnNumber(options.session);
-
     // rerun the operation
     server[op](ns, ops, options, callback);
   });

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -17,7 +17,7 @@ var inherits = require('util').inherits,
   createClientInfo = require('./shared').createClientInfo,
   SessionMixins = require('./shared').SessionMixins,
   isRetryableWritesSupported = require('./shared').isRetryableWritesSupported,
-  txnNumber = require('./shared').txnNumber;
+  getNextTransactionNumber = require('./shared').getNextTransactionNumber;
 
 var MongoCR = require('../auth/mongocr'),
   X509 = require('../auth/x509'),
@@ -1183,7 +1183,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
   }
 
   // increment and assign txnNumber
-  options.txnNumber = txnNumber(options.session);
+  options.txnNumber = getNextTransactionNumber(options.session);
 
   self.s.replicaSetState.primary[op](ns, ops, options, (err, result) => {
     if (!err) return callback(null, result);

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1175,7 +1175,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
 
   self.s.replicaSetState.primary[op](ns, ops, options, (err, result) => {
     if (!err) return callback(null, result);
-    if (err instanceof errors.MongoNetworkError) {
+    if (!(err instanceof errors.MongoNetworkError)) {
       return callback(err);
     }
 

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1184,9 +1184,6 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
       return callback(new MongoError('no primary server found'));
     }
 
-    // increment and assign txnNumber
-    options.txnNumber = txnNumber(options.session);
-
     // rerun the operation
     self.s.replicaSetState.primary[op](ns, ops, options, callback);
   });

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -640,15 +640,27 @@ function topologyMonitor(self, options) {
       }
 
       if (!self.s.replicaSetState.hasPrimary() && !self.s.options.secondaryOnlyConnectionAllowed) {
-        if (err) return self.emit('error', err);
-        self.emit('error', new MongoError('no primary found in replicaset or invalid replica set name'));
+        if (err) {
+          return self.emit('error', err);
+        }
+
+        self.emit(
+          'error',
+          new MongoError('no primary found in replicaset or invalid replica set name')
+        );
         return self.destroy({ force: true });
       } else if (
         !self.s.replicaSetState.hasSecondary() &&
         self.s.options.secondaryOnlyConnectionAllowed
       ) {
-        if (err) return self.emit('error', err);
-        self.emit('error', new MongoError('no secondary found in replicaset or invalid replica set name'));
+        if (err) {
+          return self.emit('error', err);
+        }
+
+        self.emit(
+          'error',
+          new MongoError('no secondary found in replicaset or invalid replica set name')
+        );
         return self.destroy({ force: true });
       }
 
@@ -1128,7 +1140,7 @@ ReplSet.prototype.isDestroyed = function() {
 ReplSet.prototype.getServer = function(options) {
   // Ensure we have no options
   options = options || {};
-  // Pick the right server baspickServerd on readPreference
+  // Pick the right server based on readPreference
   var server = this.s.replicaSetState.pickServer(options.readPreference);
   if (this.s.debug) this.emit('pickedServer', options.readPreference, server);
   return server;
@@ -1179,12 +1191,11 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
       return callback(err);
     }
 
-    // check again, this might have changed in the interim
     if (self.s.replicaSetState.primary == null) {
       return callback(new MongoError('no primary server found'));
     }
 
-    // rerun the operation
+    // Re-execute the command
     self.s.replicaSetState.primary[op](ns, ops, options, callback);
   });
 };

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1187,7 +1187,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
 
   self.s.replicaSetState.primary[op](ns, ops, options, (err, result) => {
     if (!err) return callback(null, result);
-    if (!(err instanceof errors.MongoNetworkError)) {
+    if (!(err instanceof errors.MongoNetworkError) && !err.message.match(/not master/)) {
       return callback(err);
     }
 

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1210,6 +1210,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session=null] Session to use for the operation
+ * @param {boolean} [options.retryWrites] Enable retryable writes for this operation
  * @param {opResultCallback} callback A callback function
  */
 ReplSet.prototype.insert = function(ns, ops, options, callback) {
@@ -1238,6 +1239,7 @@ ReplSet.prototype.insert = function(ns, ops, options, callback) {
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session=null] Session to use for the operation
+ * @param {boolean} [options.retryWrites] Enable retryable writes for this operation
  * @param {opResultCallback} callback A callback function
  */
 ReplSet.prototype.update = function(ns, ops, options, callback) {
@@ -1266,6 +1268,7 @@ ReplSet.prototype.update = function(ns, ops, options, callback) {
  * @param {Boolean} [options.serializeFunctions=false] Specify if functions on an object should be serialized.
  * @param {Boolean} [options.ignoreUndefined=false] Specify if the BSON serializer should ignore undefined fields.
  * @param {ClientSession} [options.session=null] Session to use for the operation
+ * @param {boolean} [options.retryWrites] Enable retryable writes for this operation
  * @param {opResultCallback} callback A callback function
  */
 ReplSet.prototype.remove = function(ns, ops, options, callback) {

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -430,7 +430,7 @@ const isRetryableWritesSupported = function(topology) {
  *
  * @param {ClientSession} session
  */
-const txnNumber = function(session) {
+const getNextTransactionNumber = function(session) {
   session.serverSession.txnNumber++;
   return BSON.Long.fromNumber(session.serverSession.txnNumber);
 };
@@ -449,4 +449,4 @@ module.exports.diff = diff;
 module.exports.Interval = Interval;
 module.exports.Timeout = Timeout;
 module.exports.isRetryableWritesSupported = isRetryableWritesSupported;
-module.exports.txnNumber = txnNumber;
+module.exports.getNextTransactionNumber = getNextTransactionNumber;

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -56,6 +56,11 @@ var executeWrite = function(pool, bson, type, opsField, ns, ops, options, callba
     writeCommand.bypassDocumentValidation = options.bypassDocumentValidation;
   }
 
+  // optionally add a `txnNumber` if retryable writes are being attempted
+  if (typeof options.txnNumber !== 'undefined') {
+    writeCommand.txnNumber = options.txnNumber;
+  }
+
   // Options object
   var opts = { command: true };
   if (typeof options.session !== 'undefined') opts.session = options.session;

--- a/test/tests/unit/common.js
+++ b/test/tests/unit/common.js
@@ -11,28 +11,29 @@ class ReplSetFixture {
     this.electionIds = [new ObjectId(), new ObjectId()];
   }
 
-  setup() {
-    return Promise.all([
-      mock.createServer(),
-      mock.createServer(),
-      mock.createServer()
-    ]).then(servers => {
-      this.servers = servers;
-      this.primaryServer = servers[0];
-      this.firstSecondaryServer = servers[1];
-      this.arbiterServer = servers[2];
+  setup(options) {
+    options = options || {};
+    const ismaster = options.ismaster ? options.ismaster : mock.DEFAULT_ISMASTER;
 
-      this.defaultFields = assign({}, mock.DEFAULT_ISMASTER, {
-        setName: 'rs',
-        setVersion: 1,
-        electionId: this.electionIds[0],
-        hosts: this.servers.map(server => server.uri()),
-        arbiters: [this.arbiterServer.uri()]
-      });
+    return Promise.all([mock.createServer(), mock.createServer(), mock.createServer()]).then(
+      servers => {
+        this.servers = servers;
+        this.primaryServer = servers[0];
+        this.firstSecondaryServer = servers[1];
+        this.arbiterServer = servers[2];
 
-      this.defineReplSetStates();
-      this.configureMessageHandlers();
-    });
+        this.defaultFields = assign({}, ismaster, {
+          setName: 'rs',
+          setVersion: 1,
+          electionId: this.electionIds[0],
+          hosts: this.servers.map(server => server.uri()),
+          arbiters: [this.arbiterServer.uri()]
+        });
+
+        this.defineReplSetStates();
+        this.configureMessageHandlers();
+      }
+    );
   }
 
   defineReplSetStates() {

--- a/test/tests/unit/common.js
+++ b/test/tests/unit/common.js
@@ -92,6 +92,19 @@ class ReplSetFixture {
   }
 }
 
+class MongosFixture {
+  setup(options) {
+    options = options || {};
+    const ismaster = options.ismaster ? options.ismaster : mock.DEFAULT_ISMASTER;
+    return Promise.all([mock.createServer(), mock.createServer()]).then(servers => {
+      this.servers = servers;
+      this.defaultFields = Object.assign({}, ismaster, {
+        msg: 'isdbgrid'
+      });
+    });
+  }
+}
+
 /**
  * Creates a cluster time for use in unit testing cluster time gossiping and
  * causal consistency.
@@ -111,5 +124,6 @@ function genClusterTime(time) {
 
 module.exports = {
   ReplSetFixture: ReplSetFixture,
+  MongosFixture: MongosFixture,
   genClusterTime: genClusterTime
 };

--- a/test/tests/unit/mongos/retryable_writes_tests.js
+++ b/test/tests/unit/mongos/retryable_writes_tests.js
@@ -58,4 +58,59 @@ describe('Retryable Writes (Mongos)', function() {
       topology.connect();
     }
   });
+
+  it('should retry write commands where `retryWrites` is true, and not increment `txnNumber`', {
+    metadata: { requires: { topology: ['single'] } },
+    test: function(done) {
+      const mongos = new Mongos(test.servers.map(server => server.address()), {
+        connectionTimeout: 3000,
+        socketTimeout: 0,
+        haInterval: 10000,
+        localThresholdMS: 500,
+        size: 1
+      });
+
+      const sessionPool = new ServerSessionPool(mongos);
+      const session = new ClientSession(mongos, sessionPool);
+
+      let command = null,
+        insertCount = 0;
+
+      const messageHandler = () => {
+        return request => {
+          const doc = request.document;
+          if (doc.ismaster) {
+            request.reply(test.defaultFields);
+          } else if (doc.insert) {
+            insertCount++;
+            if (insertCount === 1) {
+              request.connection.destroy();
+            } else {
+              command = doc;
+              request.reply({ ok: 1 });
+            }
+          }
+        };
+      };
+
+      test.servers[0].setMessageHandler(messageHandler('MONGOS1'));
+      test.servers[1].setMessageHandler(messageHandler('MONGOS2'));
+      mongos.once('fullsetup', function() {
+        mongos.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+          err
+        ) {
+          if (err) console.dir(err);
+          expect(err).to.not.exist;
+          expect(command).to.have.property('txnNumber');
+          expect(command.txnNumber).to.eql(1);
+
+          mongos.destroy();
+          done();
+        });
+      });
+
+      mongos.on('error', done);
+      mongos.connect();
+    }
+  });
 });

--- a/test/tests/unit/mongos/retryable_writes_tests.js
+++ b/test/tests/unit/mongos/retryable_writes_tests.js
@@ -113,4 +113,58 @@ describe('Retryable Writes (Mongos)', function() {
       mongos.connect();
     }
   });
+
+  it('should retry write commands where `retryWrites` is true, and there is a "not master" error', {
+    metadata: { requires: { topology: ['single'] } },
+    test: function(done) {
+      const mongos = new Mongos(test.servers.map(server => server.address()), {
+        connectionTimeout: 3000,
+        socketTimeout: 0,
+        haInterval: 10000,
+        localThresholdMS: 500,
+        size: 1
+      });
+
+      const sessionPool = new ServerSessionPool(mongos);
+      const session = new ClientSession(mongos, sessionPool);
+
+      let command = null,
+        insertCount = 0;
+
+      const messageHandler = () => {
+        return request => {
+          const doc = request.document;
+          if (doc.ismaster) {
+            request.reply(test.defaultFields);
+          } else if (doc.insert) {
+            insertCount++;
+            if (insertCount === 1) {
+              request.reply({ ok: 0, errmsg: 'not master' }); // simulate a stepdown
+            } else {
+              command = doc;
+              request.reply({ ok: 1 });
+            }
+          }
+        };
+      };
+
+      test.servers[0].setMessageHandler(messageHandler('MONGOS1'));
+      test.servers[1].setMessageHandler(messageHandler('MONGOS2'));
+      mongos.once('fullsetup', function() {
+        mongos.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+          err
+        ) {
+          expect(err).to.not.exist;
+          expect(command).to.have.property('txnNumber');
+          expect(command.txnNumber).to.eql(1);
+
+          mongos.destroy();
+          done();
+        });
+      });
+
+      mongos.on('error', done);
+      mongos.connect();
+    }
+  });
 });

--- a/test/tests/unit/mongos/retryable_writes_tests.js
+++ b/test/tests/unit/mongos/retryable_writes_tests.js
@@ -1,0 +1,61 @@
+'use strict';
+var expect = require('chai').expect,
+  Mongos = require('../../../../lib/topologies/mongos'),
+  mock = require('../../../mock'),
+  MongosFixture = require('../common').MongosFixture,
+  ClientSession = require('../../../../lib/sessions').ClientSession,
+  ServerSessionPool = require('../../../../lib/sessions').ServerSessionPool;
+
+const test = new MongosFixture();
+describe('Retryable Writes (Mongos)', function() {
+  afterEach(() => mock.cleanup());
+  beforeEach(() => test.setup({ ismaster: mock.DEFAULT_ISMASTER_36 }));
+
+  it('should add `txnNumber` to write commands where `retryWrites` is true', {
+    metadata: { requires: { topology: ['single'] } },
+    test: function(done) {
+      const topology = new Mongos(test.servers.map(server => server.address()), {
+        connectionTimeout: 3000,
+        socketTimeout: 0,
+        haInterval: 10000,
+        localThresholdMS: 500,
+        size: 1
+      });
+
+      const sessionPool = new ServerSessionPool(topology);
+      const session = new ClientSession(topology, sessionPool);
+
+      let command = null;
+      const messageHandler = () => {
+        return request => {
+          const doc = request.document;
+          if (doc.ismaster) {
+            request.reply(test.defaultFields);
+          } else if (doc.insert) {
+            command = doc;
+            request.reply({ ok: 1 });
+          }
+        };
+      };
+
+      test.servers[0].setMessageHandler(messageHandler('MONGOS1'));
+      test.servers[1].setMessageHandler(messageHandler('MONGOS2'));
+
+      topology.once('fullsetup', function() {
+        topology.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+          err
+        ) {
+          expect(err).to.not.exist;
+          expect(command).to.have.property('txnNumber');
+          expect(command.txnNumber).to.eql(1);
+
+          topology.destroy();
+          done();
+        });
+      });
+
+      topology.on('error', done);
+      topology.connect();
+    }
+  });
+});

--- a/test/tests/unit/replset/retryable_writes_tests.js
+++ b/test/tests/unit/replset/retryable_writes_tests.js
@@ -1,0 +1,59 @@
+'use strict';
+var expect = require('chai').expect,
+  ReplSet = require('../../../../lib/topologies/replset'),
+  mock = require('../../../mock'),
+  ReplSetFixture = require('../common').ReplSetFixture,
+  ClientSession = require('../../../../lib/sessions').ClientSession,
+  ServerSessionPool = require('../../../../lib/sessions').ServerSessionPool;
+
+const test = new ReplSetFixture();
+describe('Sessions (ReplSet)', function() {
+  afterEach(() => mock.cleanup());
+  beforeEach(() => test.setup({ ismaster: mock.DEFAULT_ISMASTER_36 }));
+
+  it('should add `txnNumber` to write commands where `retryWrites` is true', {
+    metadata: { requires: { topology: ['single'] } },
+    test: function(done) {
+      var replset = new ReplSet(
+        [test.primaryServer.address(), test.firstSecondaryServer.address()],
+        {
+          setName: 'rs',
+          connectionTimeout: 3000,
+          socketTimeout: 0,
+          haInterval: 100,
+          size: 1
+        }
+      );
+
+      const sessionPool = new ServerSessionPool(replset);
+      const session = new ClientSession(replset, sessionPool);
+
+      let command = null;
+      test.primaryServer.setMessageHandler(request => {
+        const doc = request.document;
+        if (doc.ismaster) {
+          request.reply(test.primaryStates[0]);
+        } else if (doc.insert) {
+          command = doc;
+          request.reply({ ok: 1 });
+        }
+      });
+
+      replset.on('all', () => {
+        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+          err
+        ) {
+          expect(err).to.not.exist;
+          expect(command).to.have.property('txnNumber');
+          expect(command.txnNumber).to.eql(1);
+
+          replset.destroy();
+          done();
+        });
+      });
+
+      replset.on('error', done);
+      replset.connect();
+    }
+  });
+});

--- a/test/tests/unit/replset/retryable_writes_tests.js
+++ b/test/tests/unit/replset/retryable_writes_tests.js
@@ -111,4 +111,58 @@ describe('Retryable Writes (ReplSet)', function() {
       replset.connect();
     }
   });
+
+  it('should retry write commands where `retryWrites` is true, and there is a "not master" error', {
+    metadata: { requires: { topology: ['single'] } },
+    test: function(done) {
+      var replset = new ReplSet(
+        [test.primaryServer.address(), test.firstSecondaryServer.address()],
+        {
+          setName: 'rs',
+          connectionTimeout: 100,
+          socketTimeout: 0,
+          haInterval: 100,
+          size: 5,
+          minSize: 1
+        }
+      );
+
+      const sessionPool = new ServerSessionPool(replset);
+      const session = new ClientSession(replset, sessionPool);
+
+      let command = null,
+        insertCount = 0;
+
+      test.primaryServer.setMessageHandler(request => {
+        const doc = request.document;
+        if (doc.ismaster) {
+          request.reply(test.primaryStates[0]);
+        } else if (doc.insert) {
+          insertCount++;
+          if (insertCount === 1) {
+            request.reply({ ok: 0, errmsg: 'not master' }); // simulate a stepdown
+          } else {
+            command = doc;
+            request.reply({ ok: 1 });
+          }
+        }
+      });
+
+      replset.on('all', () => {
+        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+          err
+        ) {
+          expect(err).to.not.exist;
+          expect(command).to.have.property('txnNumber');
+          expect(command.txnNumber).to.eql(1);
+
+          replset.destroy();
+          done();
+        });
+      });
+
+      replset.on('error', done);
+      replset.connect();
+    }
+  });
 });

--- a/test/tests/unit/replset/retryable_writes_tests.js
+++ b/test/tests/unit/replset/retryable_writes_tests.js
@@ -56,4 +56,59 @@ describe('Retryable Writes (ReplSet)', function() {
       replset.connect();
     }
   });
+
+  it('should retry write commands where `retryWrites` is true, and not increment `txnNumber`', {
+    metadata: { requires: { topology: ['single'] } },
+    test: function(done) {
+      var replset = new ReplSet(
+        [test.primaryServer.address(), test.firstSecondaryServer.address()],
+        {
+          setName: 'rs',
+          connectionTimeout: 100,
+          socketTimeout: 0,
+          haInterval: 100,
+          size: 5,
+          minSize: 1
+        }
+      );
+
+      const sessionPool = new ServerSessionPool(replset);
+      const session = new ClientSession(replset, sessionPool);
+
+      let command = null,
+        insertCount = 0;
+
+      test.primaryServer.setMessageHandler(request => {
+        const doc = request.document;
+        if (doc.ismaster) {
+          request.reply(test.primaryStates[0]);
+        } else if (doc.insert) {
+          insertCount++;
+          if (insertCount === 1) {
+            request.connection.destroy();
+          } else {
+            command = doc;
+            request.reply({ ok: 1 });
+          }
+        }
+      });
+
+      replset.on('all', () => {
+        replset.insert('test.test', [{ a: 1 }], { retryWrites: true, session: session }, function(
+          err
+        ) {
+          if (err) console.dir(err);
+          expect(err).to.not.exist;
+          expect(command).to.have.property('txnNumber');
+          expect(command.txnNumber).to.eql(1);
+
+          replset.destroy();
+          done();
+        });
+      });
+
+      replset.on('error', done);
+      replset.connect();
+    }
+  });
 });

--- a/test/tests/unit/replset/retryable_writes_tests.js
+++ b/test/tests/unit/replset/retryable_writes_tests.js
@@ -7,7 +7,7 @@ var expect = require('chai').expect,
   ServerSessionPool = require('../../../../lib/sessions').ServerSessionPool;
 
 const test = new ReplSetFixture();
-describe('Sessions (ReplSet)', function() {
+describe('Retryable Writes (ReplSet)', function() {
   afterEach(() => mock.cleanup());
   beforeEach(() => test.setup({ ismaster: mock.DEFAULT_ISMASTER_36 }));
 


### PR DESCRIPTION
ticket: https://jira.mongodb.org/browse/NODE-1105
spec: https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst

This implements the basic building blocks for support for retryable writes in the core driver.  The code sections are implementations of the pseudocode documented in the spec linked above.  The feature is "enabled" on supported servers by passing a `retryWrites: true` option down to the topology's supported write operations (insert/update/remove), as well as a valid session.  All other details should be covered by the spec.

It should be mentioned that this includes a preliminary bug fix for the pool supporting a "minimum pool size".  This was a problem encountered during testing because the simulation of a lost connection resulted in a pool which never increased in size for a subsequent write operation - not a situation that's likely to occur in the real world, but something we eventually want in a pool refactor.  It defaults to 0 (no change in behavior from the status quo), but works well enough for the test case I needed.  Consider this work incomplete, but working. 