### PR TITLE
Don't redeclare BSON variable

### DIFF
--- a/lib/auth/plain.js
+++ b/lib/auth/plain.js
@@ -8,7 +8,7 @@ var f = require('util').format
   , Query = require('../connection/commands').Query
   , MongoError = require('../error');
 
-var BSON = retrieveBSON();
+BSON = retrieveBSON();
 
 var AuthSession = function(db, username, password) {
   this.db = db;

--- a/lib/auth/plain.js
+++ b/lib/auth/plain.js
@@ -3,12 +3,12 @@
 var BSON = require('bson');
 
 var f = require('util').format
-  , Binary = BSON.Binary
   , retrieveBSON = require('../connection/utils').retrieveBSON
   , Query = require('../connection/commands').Query
   , MongoError = require('../error');
 
-BSON = retrieveBSON();
+var BSON = retrieveBSON()
+  , Binary = BSON.Binary;
 
 var AuthSession = function(db, username, password) {
   this.db = db;


### PR DESCRIPTION
This fixes a problem that arises when using Rollup to bundle an application that uses this library.

```
[!] Error: Identifier 'BSON' has already been declared
node_modules/mongodb-core/lib/auth/plain.js (11:4)
 9:   , MongoError = require('../error');
10:
11: var BSON = retrieveBSON();
        ^
12:
13: var AuthSession = function(db, username, password) {
```