### PR TITLE
pool - Corrects domain issue on _createConnection

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -1051,6 +1051,15 @@ function removeConnection(self, connection) {
 var handlers = ["close", "message", "error", "timeout", "parseError", "connect"];
 
 function _createConnection(self) {
+  if (self.options.domainsEnabled === true && process.domain) {
+    // it is not valid to create a connection on a domain since the queries themselves are bound via the domain
+    // so if we get here on a domain, we exit so the connection and all it's future queries aren't forever coupled to that domain
+    process.domain.exit();
+    return process.nextTick(function() {
+      return _createConnection(self);
+    });
+  }
+  
   if(self.state == DESTROYED || self.state == DESTROYING) {
     return;
   }


### PR DESCRIPTION
I'll start with, I hate domains, but while working on some unit tests we discovered an issue related to issuing queries in a rapid fire manner which caused our domains to go haywire. After a lot of tracing we discovered the root problem.

Right now, due to a pull request I made some time ago you guys added a setting for binding the query callback to the domain that it was originally initiated on. That works fine. The problem is inside pool.js there is a spot where you will dynamically grow the pool after queries have been initiated. This can cause a call to `.find()` to result in a new pool member. If the `.find()` was on a domain, then the new pool member is *permanently bound to the domain*. So all future queries from that pool member, whether or not they originate from a domain, will be bound to a domain, because it was created inside the internal callback structure of the `.find()`.

Here's a psuedo-code example

```js
setTimeout(function() {
	domain.run(function() {
		process.domain.id = "test!";
		// if this .find() triggers a growing of the pool via _createConnection, then the new pool member is permanently bound to the domain
		collection.find(someFilter).toArray(function() {
			domain.exit();
                        // do something
		})
	});
}, 5);

setTimeout(function() {
	console.log("process.domain.id", process.domain.id);
	// undefined, as it should
	collection.find(someFilter).toArray(function() {
		console.log("process.domain.id", process.domain.id);
		// test!
		// we've become bound to a previous domain because the pool connection that served us was created on a domain
	});
}, 15);
```

To me this makes sense because the purpose of `domainsEnabled` is to bind queries to a domain. So that way if I issue a query on a domain, my callback is still on that domain. Now, if you guys want to be absolute sticklers, it could be refined so that we would check if the original Pool.connect was called on a domain, and if so, we could preserve THAT domain, but no others. I just don't know how realistic that use-case is. If that's what you would like I can correct the pull request.