### PR TITLE
fix(sessions): ensure that we ignore session details from arbiters

### DIFF
--- a/lib/topologies/replset_state.js
+++ b/lib/topologies/replset_state.js
@@ -200,6 +200,8 @@ ReplSetState.prototype.remove = function(server, options) {
   }
 };
 
+const isArbiter = ismaster => ismaster.arbiterOnly && ismaster.setName;
+
 ReplSetState.prototype.update = function(server) {
   var self = this;
   // Get the current ismaster
@@ -266,7 +268,7 @@ ReplSetState.prototype.update = function(server) {
   }
 
   // Update logicalSessionTimeoutMinutes
-  if (ismaster.logicalSessionTimeoutMinutes !== undefined) {
+  if (ismaster.logicalSessionTimeoutMinutes !== undefined && !isArbiter(ismaster)) {
     if (
       self.logicalSessionTimeoutMinutes === undefined ||
       ismaster.logicalSessionTimeoutMinutes === null
@@ -597,8 +599,7 @@ ReplSetState.prototype.update = function(server) {
   // Arbiter handling
   //
   if (
-    ismaster.arbiterOnly &&
-    ismaster.setName &&
+    isArbiter(ismaster) &&
     !inList(ismaster, server, this.arbiters) &&
     this.setName &&
     this.setName === ismaster.setName

--- a/test/mock/lib/server.js
+++ b/test/mock/lib/server.js
@@ -135,7 +135,11 @@ Server.prototype.start = function() {
     self.on('message', function(message, connection) {
       var request = new Request(self, connection, message);
       if (self.messageHandler) {
-        self.messageHandler(request);
+        try {
+          self.messageHandler(request);
+        } catch (err) {
+          console.log(err.stack);
+        }
       } else {
         self.messages.push(request);
       }


### PR DESCRIPTION
Arbiters in a ReplSet should not be taken into consideration if
they report a `logicalSessionTimeoutMinutes`.

NODE-1188