### PR TITLE
Remove listener when mongos destroyed

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -299,10 +299,15 @@ Mongos.prototype.connect = function(options) {
     );
   });
 
+  const serverDescriptionChangedCallback = event => {
+    self.emit('serverDescriptionChanged', event);
+  };
+
   servers.forEach(function(server) {
-    server.on('serverDescriptionChanged', function(event) {
-      self.emit('serverDescriptionChanged', event);
-    });
+    server.on('serverDescriptionChanged', serverDescriptionChangedCallback);
+    server.on('destroy', () =>
+      server.removeListener('serverDescriptionChanged', serverDescriptionChangedCallback)
+    );
   });
 
   // Emit the topology opening event
@@ -850,10 +855,6 @@ Mongos.prototype.destroy = function(options) {
     x.destroy(options);
     // Move to list of disconnectedProxies
     moveServerFrom(self.connectedProxies, self.disconnectedProxies, x);
-  });
-  // Remove all listeners
-  self.disconnectedProxies.forEach(p => {
-    p.removeAllListeners();
   });
   // Emit the final topology change
   emitTopologyDescriptionChanged(self);

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -273,11 +273,6 @@ function emitSDAMEvent(self, event, description) {
   if (self.listeners(event).length > 0) {
     self.emit(event, description);
   }
-  if (event === 'topologyClosed') {
-    if (self.disconnectedProxies) {
-      self.disconnectedProxies.forEach(p => { p.removeAllListeners(); } )
-    }
-  }
 }
 
 /**
@@ -856,7 +851,10 @@ Mongos.prototype.destroy = function(options) {
     // Move to list of disconnectedProxies
     moveServerFrom(self.connectedProxies, self.disconnectedProxies, x);
   });
-
+  // Remove all listeners
+  self.disconnectedProxies.forEach(p => {
+    p.removeAllListeners();
+  });
   // Emit the final topology change
   emitTopologyDescriptionChanged(self);
   // Emit toplogy closing event

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -273,6 +273,11 @@ function emitSDAMEvent(self, event, description) {
   if (self.listeners(event).length > 0) {
     self.emit(event, description);
   }
+  if (event === 'topologyClosed') {
+    if (self.disconnectedProxies) {
+      self.disconnectedProxies.forEach(p => { p.removeAllListeners(); } )
+    }
+  }
 }
 
 /**

--- a/test/tests/unit/mongos/events_tests.js
+++ b/test/tests/unit/mongos/events_tests.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const expect = require('chai').expect;
+const Mongos = require('../../../../lib/topologies/mongos');
+const mock = require('../../../mock');
+const MongosFixture = require('../common').MongosFixture;
+
+const test = new MongosFixture();
+
+describe.only('EventEmitters (Mongos)', function() {
+  afterEach(() => mock.cleanup());
+  beforeEach(() => {
+    return mock.createServer().then(mockServer => {
+      test.server = mockServer;
+    });
+  });
+
+  it('should remove all event listeners when server is closed', {
+    metadata: { requires: { topology: ['single'] } },
+    test: function(done) {
+      test.server.setMessageHandler(req => {
+        const doc = req.document;
+        if (doc.ismaster) {
+          req.reply(Object.assign({}, test.defaultFields));
+        }
+      });
+
+      const mongos = new Mongos([test.server.address()], {
+        connectionTimeout: 30000,
+        socketTimeout: 30000,
+        haInterval: 500,
+        size: 1
+      });
+
+      mongos.on('error', done);
+      mongos.once('connect', () => {
+        // After we connect, destroy/close the server
+        mongos.destroy();
+        mongos.disconnectedProxies.forEach(p => {
+          // There should be no listeners remaining
+          expect(p.listenerCount()).to.equal(0);
+        });
+        done();
+      });
+
+      mongos.connect();
+    }
+  });
+});

--- a/test/tests/unit/mongos/events_tests.js
+++ b/test/tests/unit/mongos/events_tests.js
@@ -15,7 +15,7 @@ describe.only('EventEmitters (Mongos)', function() {
     });
   });
 
-  it('should remove all event listeners when server is closed', {
+  it('should remove `serverDescriptionChanged` listeners when server is closed', {
     metadata: { requires: { topology: ['single'] } },
     test: function(done) {
       test.server.setMessageHandler(req => {
@@ -34,12 +34,17 @@ describe.only('EventEmitters (Mongos)', function() {
 
       mongos.on('error', done);
       mongos.once('connect', () => {
+        expect(mongos.disconnectedProxies).to.have.length(1);
+        expect(mongos.disconnectedProxies[0].listenerCount('serverDescriptionChanged')).to.equal(1);
         // After we connect, destroy/close the server
         mongos.destroy();
-        mongos.disconnectedProxies.forEach(p => {
-          // There should be no listeners remaining
-          expect(p.listenerCount()).to.equal(0);
+        mongos.on('topologyClosed', () => {
+          expect(mongos.disconnectedProxies).to.have.length(1);
+          expect(mongos.disconnectedProxies[0].listenerCount('serverDescriptionChanged')).to.equal(
+            0
+          );
         });
+
         done();
       });
 

--- a/test/tests/unit/mongos/events_tests.js
+++ b/test/tests/unit/mongos/events_tests.js
@@ -7,7 +7,7 @@ const MongosFixture = require('../common').MongosFixture;
 
 const test = new MongosFixture();
 
-describe.only('EventEmitters (Mongos)', function() {
+describe('EventEmitters (Mongos)', function() {
   afterEach(() => mock.cleanup());
   beforeEach(() => {
     return mock.createServer().then(mockServer => {


### PR DESCRIPTION
Not all of the listeners were being removed when a server was closed, causing a memory leak on reconnect. 

This removes the `serverDescriptionChanged` listener when a server has been closed.

NODE-1216