### PR TITLE
fix(secondaries): fixes connection with secondary readPreference

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -669,6 +669,26 @@ function applyAuthenticationContexts(self, server, callback) {
   applyAuth(authContexts, server, callback);
 }
 
+function shouldTriggerConnect(self) {
+  var secondaryReadPreferenceString = ReadPreference.secondary.preference || ReadPreference.secondary.mode;
+  var currentReadPreferenceString = self.s.connectOptions.readPreference && (
+    self.s.connectOptions.readPreference.preference ||
+    self.s.connectOptions.readPreference.mode
+  );
+
+  var isConnecting = self.state === CONNECTING;
+  var hasPrimary = self.s.replicaSetState.hasPrimary();
+  var hasSecondary = self.s.replicaSetState.hasSecondary();
+  var secondaryOnlyConnectionAllowed = self.s.options.secondaryOnlyConnectionAllowed;
+  var readPreferenceSecondary = secondaryReadPreferenceString === currentReadPreferenceString;
+
+  return (
+    (isConnecting &&
+      ((readPreferenceSecondary && hasSecondary) || (!readPreferenceSecondary && hasPrimary))) ||
+    (hasSecondary && secondaryOnlyConnectionAllowed)
+  );
+}
+
 function handleInitialConnectEvent(self, event) {
   return function() {
     var _this = this;
@@ -716,8 +736,7 @@ function handleInitialConnectEvent(self, event) {
           _this.on('parseError', handleEvent(self, 'parseError'));
 
           // Do we have a primary or primaryAndSecondary
-          if(self.state === CONNECTING && self.s.replicaSetState.hasPrimary()
-            || (self.s.replicaSetState.hasSecondary() && self.s.options.secondaryOnlyConnectionAllowed)) {
+          if(shouldTriggerConnect(self)) {
             // We are connected
             self.state = CONNECTED;
 


### PR DESCRIPTION
Ensures that when readPreference is `secondary`, the `connect`
event is not triggered until connection has been established
with a secondary.

Backport of NODE-1089 to 2.0

@mbroadst @jlord Do you want to see unit tests on this? We don't have the benefit of the replset fixture, so they will be messy.