### PR TITLE
fix(sdam): more explicit wire protocol error message

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -363,7 +363,18 @@ var eventHandler = function(self, event) {
 
           if (!isSupportedServer(result.result)) {
             self.destroy();
-            return self.emit('error', new MongoError('unsupported server version'), self);
+            const latestSupportedVersion = '2.6';
+            const message =
+              'Server at ' +
+              self.s.options.host +
+              ':' +
+              self.s.options.port +
+              ' reports wire version ' +
+              (result.result.maxWireVersion || 0) +
+              ', but this version of Node.js Driver requires at least 2 (MongoDB' +
+              latestSupportedVersion +
+              ').';
+            return self.emit('error', new MongoError(message), self);
           }
 
           // Determine whether the server is instructing us to use a compressor

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -1055,7 +1055,7 @@ describe('Server tests', function() {
 
       test: function(done) {
         server.setMessageHandler(request => {
-          request.reply({ ok: 1, maxWireVersion: 1 });
+          request.reply(Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 1 }));
         });
 
         const client = new Server(server.address());

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -1055,7 +1055,7 @@ describe('Server tests', function() {
 
       test: function(done) {
         server.setMessageHandler(request => {
-          request.reply({ ok: 1 });
+          request.reply({ ok: 1, maxWireVersion: 1 });
         });
 
         const client = new Server(server.address());


### PR DESCRIPTION
This updates the error message received when a user attempts to connect to a server running an older version of MongoDB than the latest Node.js Driver version supports. For instance, using the 3.x version of the driver to connect to a server running something below MongoDB 2.6. 

@daprahamian and I paired on this PR 💯 

@mbroadst do you think we should break up the error messages into other files to do more explicit testing?

NODE-1186