### PR TITLE
Cannot set _called property on number.

### DIFF
--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -214,14 +214,14 @@ function Interval(fn, time) {
 
 function Timeout(fn, time) {
   var timer = false;
+  this._called = false;
 
   this.start = function () {
     if (!this.isRunning()) {
       timer = setTimeout(function() {
         fn();
-        if (timer && timer._called === undefined) {
-          // The artificial _called is set here for compatibility with node.js 0.10.x/0.12.x versions
-          timer._called = true;
+        if (timer && !this._called) {
+          this._called = true;
         }
       }, time);
     }
@@ -235,7 +235,7 @@ function Timeout(fn, time) {
   };
 
   this.isRunning = function () {
-    if(timer && timer._called) return false;
+    if (timer && this._called) return false;
     return timer !== false;
   };
 }


### PR DESCRIPTION
Background:

Compass is currently generating tons of errors when connecting to replica sets on our latest master, because of the `Timeout` object in the shared topology:

![screen shot 2018-01-26 at 12 49 22 pm](https://user-images.githubusercontent.com/9030/35439791-ad1b1ae4-029c-11e8-9d6d-6e0acb697f5e.png)

Basically it's trying to set a property `_called` on a number, which is invalid in this context for some reason (I can do this from the console all day long with no issue). The number is the return value of the `setTimeout` function, which is the expected return value of that function.

There was a comment that the `_called` property was there for Node compatibility, altough I'm not sure why it was needed. First of all, Node's `Timeout` object has this set as an instance property on the `Timeout` object itself, not the result of the `setTimeout` method, so the code wouldn't be API compatible with that object anyways.

https://github.com/nodejs/node/blob/v7.9.0/lib/timers.js#L478

I haven't been able to peg down exactly why this started happening or exactly when as of yet, but I have tested this new code in Compass and the error goes away.
