### PR TITLE
fix(retryableWrites): only remove primary after retry

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1212,13 +1212,13 @@ function executeWriteOperation(args, options, callback) {
       return callback(err);
     }
 
-    // Per SDAM, remove primary from replicaset
-    self.s.replicaSetState.remove(self.s.replicaSetState.primary, { force: true });
-
     if (willRetryWrite) {
       const newArgs = Object.assign({}, args, { retrying: true });
       return executeWriteOperation(newArgs, options, callback);
     }
+
+    // Per SDAM, remove primary from replicaset
+    self.s.replicaSetState.remove(self.s.replicaSetState.primary, { force: true });
 
     return callback(err);
   };


### PR DESCRIPTION
Make sure to not remove the primary on an error until after the retry