### PR TITLE
fix(connection): make pool not try to reconnect forever when reconnectTries = 0

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -364,7 +364,7 @@ function attemptReconnect(self) {
         // Count down the number of reconnects
         self.retriesLeft = self.retriesLeft - 1;
         // How many retries are left
-        if (self.retriesLeft === 0) {
+        if (self.retriesLeft <= 0) {
           // Destroy the instance
           self.destroy();
           // Emit close event

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -1077,4 +1077,27 @@ describe('Server tests', function() {
       }
     });
   });
+
+  it('Should not try to reconnect forever if reconnectTries = 0', {
+    metadata: { requires: { topology: 'single' } },
+
+    test: function(done) {
+      // Attempt to connect
+      let server = new Server({
+        host: 'doesntexist',
+        bson: new Bson(),
+        reconnectTries: 0
+      });
+
+      // Add event listeners
+      server.on('error', function() {});
+
+      // Start connection
+      server.connect();
+
+      server.s.pool.on('reconnectFailed', function() {
+        done();
+      });
+    }
+  });
 });


### PR DESCRIPTION
This is a somewhat strange case. The below script will print an error immediately but continue retrying connecting in the background forever:

```javascript
const mongodb = require('mongodb');

mongodb.MongoClient.connect('mongodb://thisdoesntexist:27017', { reconnectTries: 0 }).
  then(() => console.log('success'), err => console.log('error', err));
```

If you set `reconnectTries` to 1, the script prints an error and then exits.

```javascript
const mongodb = require('mongodb');

mongodb.MongoClient.connect('mongodb://thisdoesntexist:27017', { reconnectTries: 1 }).
  then(() => console.log('success'), err => console.log('error', err));
```

This patch fixes that particular issue. But this issue surfaced as part of investigating Automattic/mongoose#6028, which brings up a valid concern: why does the driver continue trying to reconnect and block process exit even after it rejects the `MongoClient.connect()` promise? I was under the impression that the driver would not try to reconnect after initial connection failed.