### PR TITLE
WIP: feat(OP_MSG): adding OP_MSG implementation

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -10,9 +10,11 @@ var inherits = require('util').inherits,
   parseHeader = require('../wireprotocol/shared').parseHeader,
   decompress = require('../wireprotocol/compression').decompress,
   Response = require('./commands').Response,
+  BinMsg = require('./msg').BinMsg,
   MongoNetworkError = require('../error').MongoNetworkError,
   Logger = require('./logger'),
   OP_COMPRESSED = require('../wireprotocol/shared').opcodes.OP_COMPRESSED,
+  OP_MSG = require('../wireprotocol/shared').opcodes.OP_MSG,
   MESSAGE_HEADER_SIZE = require('../wireprotocol/shared').MESSAGE_HEADER_SIZE;
 
 var _id = 0;
@@ -300,14 +302,22 @@ var emitMessageHandler = function(self, message) {
           'Decompressing a compressed message from the server failed. The message is corrupt.'
         );
       }
+      const ResponseConstructor = msgHeader.opCode === OP_MSG ? BinMsg : Response;
       self.messageHandler(
-        new Response(self.bson, message, msgHeader, decompressedMsgBody, self.responseOptions),
+        new ResponseConstructor(
+          self.bson,
+          message,
+          msgHeader,
+          decompressedMsgBody,
+          self.responseOptions
+        ),
         self
       );
     });
   } else {
+    const ResponseConstructor = msgHeader.opCode === OP_MSG ? BinMsg : Response;
     self.messageHandler(
-      new Response(
+      new ResponseConstructor(
         self.bson,
         message,
         msgHeader,

--- a/lib/connection/msg.js
+++ b/lib/connection/msg.js
@@ -1,0 +1,204 @@
+'use strict';
+
+// Implementation of OP_MSG spec:
+// https://github.com/mongodb/specifications/blob/master/source/message/OP_MSG.rst
+//
+// struct Section {
+//   uint8 payloadType;
+//   union payload {
+//       document  document; // payloadType == 0
+//       struct sequence { // payloadType == 1
+//           int32      size;
+//           cstring    identifier;
+//           document*  documents;
+//       };
+//   };
+// };
+
+// struct OP_MSG {
+//   struct MsgHeader {
+//       int32  messageLength;
+//       int32  requestID;
+//       int32  responseTo;
+//       int32  opCode = 2013;
+//   };
+//   uint32      flagBits;
+//   Section+    sections;
+//   [uint32     checksum;]
+// };
+
+const opcodes = require('../wireprotocol/shared').opcodes;
+
+// Incrementing request id
+let _requestId = 0;
+
+// Msg Flags
+const OPTS_CHECKSUM_PRESENT = 1;
+const OPTS_MORE_TO_COME = 2;
+const OPTS_EXHAUST_ALLOWED = 1 >> 16;
+
+class Msg {
+  constructor(bson, query, options) {
+    // Basic options needed to be passed in
+    if (query == null) throw new Error('query must be specified for query');
+
+    // Basic options
+    this.bson = bson;
+    this.query = Array.isArray(query) ? query : [query];
+
+    // Ensure empty options
+    this.options = options || {};
+
+    // Additional options
+    this.requestId = Msg.getRequestId();
+
+    // Serialization option
+    this.serializeFunctions =
+      typeof options.serializeFunctions === 'boolean' ? options.serializeFunctions : false;
+    this.ignoreUndefined =
+      typeof options.ignoreUndefined === 'boolean' ? options.ignoreUndefined : false;
+    this.checkKeys = typeof options.checkKeys === 'boolean' ? options.checkKeys : false;
+    this.maxBsonSize = options.maxBsonSize || 1024 * 1024 * 16;
+
+    // flags
+    this.checksumPresent = false;
+    this.moreToCome = options.moreToCome || false;
+    this.exhaustAllowed = false;
+  }
+
+  toBin() {
+    const buffers = [];
+    let flags = 0;
+
+    if (this.checksumPresent) {
+      flags |= OPTS_CHECKSUM_PRESENT;
+    }
+
+    if (this.moreToCome) {
+      flags |= OPTS_MORE_TO_COME;
+    }
+
+    if (this.exhaustAllowed) {
+      flags |= OPTS_EXHAUST_ALLOWED;
+    }
+
+    const header = new Buffer(
+      4 * 4 + // Header
+        4 // Flags
+    );
+
+    buffers.push(header);
+
+    let totalLength = header.length;
+
+    for (let i = 0; i < this.query.length; ++i) {
+      const query = this.query[i];
+
+      const nameArgumentPair = getValidSegmentListNamePairs(query);
+      if (nameArgumentPair) {
+        // TODO: Add support for payload type 1
+        const argument = nameArgumentPair.argument;
+
+        // Add initial type 0 segment with arguments pulled up
+        const clonedQuery = Object.assign({}, query);
+        delete clonedQuery[argument];
+        totalLength += this.makeDocumentSegment(buffers, clonedQuery);
+
+        // Create type 1 query
+        totalLength += this.makeSequenceSegment(buffers, argument, query[argument]);
+      } else {
+        totalLength += this.makeDocumentSegment(buffers, query);
+      }
+    }
+
+    writeInt32ListToUint8Buffer(header, [totalLength, this.requestId, 0, opcodes.OP_MSG, flags]);
+
+    return buffers;
+  }
+
+  makeDocumentSegment(buffers, document) {
+    const payloadTypeBuffer = new Buffer(1);
+    payloadTypeBuffer[0] = 0;
+
+    const documentBuffer = this.serializeBson(document);
+
+    buffers.push(payloadTypeBuffer);
+    buffers.push(documentBuffer);
+
+    return payloadTypeBuffer.length + documentBuffer.length;
+  }
+
+  makeSequenceSegment(buffers, argument, documents) {
+    const metaBuffer = new Buffer(
+      1 + // payloadType,
+      4 + // Size of sequence
+      argument.length + // Argument length
+        1 //C string null terminator
+    );
+
+    let segmentLength = metaBuffer.length - 1;
+
+    buffers.push(metaBuffer);
+    documents.forEach(document => {
+      const documentBuffer = this.serializeBson(document);
+      segmentLength += documentBuffer.length;
+      buffers.push(documentBuffer);
+    });
+
+    metaBuffer[0] = 1 & 0x1;
+    metaBuffer[1] = segmentLength & 0xff;
+    metaBuffer[2] = (segmentLength >> 8) & 0xff;
+    metaBuffer[3] = (segmentLength >> 16) & 0xff;
+    metaBuffer[4] = (segmentLength >> 24) & 0xff;
+    metaBuffer.write(argument, 5, 'utf8');
+    metaBuffer[metaBuffer.length - 1] = 0;
+
+    return segmentLength + 1;
+  }
+
+  serializeBson(document) {
+    return this.bson.serialize(document, {
+      checkKeys: this.checkKeys,
+      serializeFunctions: this.serializeFunctions,
+      ignoreUndefined: this.ignoreUndefined
+    });
+  }
+}
+
+Msg.getRequestId = function() {
+  return ++_requestId;
+};
+
+function writeInt32ListToUint8Buffer(buffer, int32List, start) {
+  let index = start || 0;
+
+  int32List.forEach(int32 => {
+    buffer[index] = int32 & 0xff;
+    buffer[index + 1] = (int32 >> 8) & 0xff;
+    buffer[index + 2] = (int32 >> 16) & 0xff;
+    buffer[index + 3] = (int32 >> 24) & 0xff;
+    index += 4;
+  });
+
+  return index;
+}
+
+const VALID_NAME_ARGUMENT_MAPS = {
+  insert: 'documents',
+  update: 'updates',
+  delete: 'deletes'
+};
+
+function getValidSegmentListNamePairs(query) {
+  for (let name in VALID_NAME_ARGUMENT_MAPS) {
+    if (name in query) {
+      const argument = VALID_NAME_ARGUMENT_MAPS[name];
+      if (query[argument] && query[argument].length > 1) {
+        return { name, argument };
+      }
+    }
+  }
+  return false;
+}
+
+module.exports = { Msg };

--- a/lib/connection/msg.js
+++ b/lib/connection/msg.js
@@ -32,11 +32,6 @@ const opcodes = require('../wireprotocol/shared').opcodes;
 // Incrementing request id
 let _requestId = 0;
 
-// Msg Flags
-const OPTS_CHECKSUM_PRESENT = 1;
-const OPTS_MORE_TO_COME = 2;
-const OPTS_EXHAUST_ALLOWED = 1 >> 16;
-
 class Msg {
   constructor(bson, query, options) {
     // Basic options needed to be passed in
@@ -71,15 +66,15 @@ class Msg {
     let flags = 0;
 
     if (this.checksumPresent) {
-      flags |= OPTS_CHECKSUM_PRESENT;
+      flags |= Msg.flags.CHECKSUM_PRESENT;
     }
 
     if (this.moreToCome) {
-      flags |= OPTS_MORE_TO_COME;
+      flags |= Msg.flags.MORE_TO_COME;
     }
 
     if (this.exhaustAllowed) {
-      flags |= OPTS_EXHAUST_ALLOWED;
+      flags |= Msg.flags.EXHAUST_ALLOWED;
     }
 
     const header = new Buffer(
@@ -167,6 +162,12 @@ class Msg {
 
 Msg.getRequestId = function() {
   return ++_requestId;
+};
+
+Msg.flags = {
+  CHECKSUM_PRESENT: 1,
+  MORE_TO_COME: 2,
+  EXHAUST_ALLOWED: 1 << 16
 };
 
 function writeInt32ListToUint8Buffer(buffer, int32List, start) {

--- a/lib/connection/msg.js
+++ b/lib/connection/msg.js
@@ -164,6 +164,78 @@ Msg.getRequestId = function() {
   return ++_requestId;
 };
 
+class BinMsg {
+  constructor(bson, message, msgHeader, msgBody, opts) {
+    opts = opts || { promoteLongs: true, promoteValues: true, promoteBuffers: false };
+    this.parsed = false;
+    this.raw = message;
+    this.data = msgBody;
+    this.bson = bson;
+    this.opts = opts;
+
+    // Read the message header
+    this.length = msgHeader.length;
+    this.requestId = msgHeader.requestId;
+    this.responseTo = msgHeader.responseTo;
+    this.opCode = msgHeader.opCode;
+
+    // Read response flags
+    this.responseFlags = msgBody.readInt32LE(0);
+    this.checksumPresent = (this.responseFlags & Msg.flags.CHECKSUM_PRESENT) !== 0;
+    this.moreToCome = (this.responseFlags & Msg.flags.MORE_TO_COME) !== 0;
+    this.exhaustAllowed = (this.responseFlags & Msg.flags.EXHAUST_ALLOWED) !== 0;
+    this.promoteLongs = typeof opts.promoteLongs === 'boolean' ? opts.promoteLongs : true;
+    this.promoteValues = typeof opts.promoteValues === 'boolean' ? opts.promoteValues : true;
+    this.promoteBuffers = typeof opts.promoteBuffers === 'boolean' ? opts.promoteBuffers : false;
+
+    this.documents = [];
+  }
+
+  isParsed() {
+    return this.parsed;
+  }
+
+  parse(options) {
+    // Don't parse again if not needed
+    if (this.parsed) return;
+    options = options || {};
+
+    this.index = 4;
+    // Allow the return of raw documents instead of parsing
+    const raw = options.raw || false;
+    const promoteLongs =
+      typeof options.promoteLongs === 'boolean' ? options.promoteLongs : this.opts.promoteLongs;
+    const promoteValues =
+      typeof options.promoteValues === 'boolean' ? options.promoteValues : this.opts.promoteValues;
+    const promoteBuffers =
+      typeof options.promoteBuffers === 'boolean'
+        ? options.promoteBuffers
+        : this.opts.promoteBuffers;
+
+    // Set up the options
+    const _options = {
+      promoteLongs: promoteLongs,
+      promoteValues: promoteValues,
+      promoteBuffers: promoteBuffers
+    };
+
+    while (this.index < this.data.length) {
+      const payloadType = this.data.readUInt8(this.index++);
+      if (payloadType === 1) {
+        console.error('TYPE 1');
+      } else if (payloadType === 0) {
+        const bsonSize = this.data.readUInt32LE(this.index);
+        const bin = this.data.slice(this.index, this.index + bsonSize);
+        this.documents.push(raw ? bin : this.bson.deserialize(bin, _options));
+
+        this.index += bsonSize;
+      }
+    }
+
+    this.parsed = true;
+  }
+}
+
 Msg.flags = {
   CHECKSUM_PRESENT: 1,
   MORE_TO_COME: 2,
@@ -202,4 +274,4 @@ function getValidSegmentListNamePairs(query) {
   return false;
 }
 
-module.exports = { Msg };
+module.exports = { Msg, BinMsg };

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -13,6 +13,7 @@ var inherits = require('util').inherits,
   MongoNetworkError = require('../error').MongoNetworkError,
   TwoSixWireProtocolSupport = require('../wireprotocol/2_6_support'),
   ThreeTwoWireProtocolSupport = require('../wireprotocol/3_2_support'),
+  ThreeSixWireProtocolSupport = require('../wireprotocol/3_6_support'),
   BasicCursor = require('../cursor'),
   sdam = require('./shared'),
   createClientInfo = require('./shared').createClientInfo,
@@ -253,6 +254,11 @@ function isSupportedServer(response) {
 }
 
 function configureWireProtocolHandler(self, ismaster) {
+  // 3.6 wire protocol handler
+  if (ismaster.maxWireVersion >= 6) {
+    return new ThreeSixWireProtocolSupport();
+  }
+
   // 3.2 wire protocol handler
   if (ismaster.maxWireVersion >= 4) {
     return new ThreeTwoWireProtocolSupport(new TwoSixWireProtocolSupport());

--- a/lib/wireprotocol/3_6_support/execute_find.js
+++ b/lib/wireprotocol/3_6_support/execute_find.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const getReadPreference = require('../shared').getReadPreference;
+const Msg = require('../../connection/msg').Msg;
+
+function executeFind(bson, ns, cmd, cursorState, topology, options) {
+  // Ensure we have at least some options
+  options = options || {};
+  // Get the readPreference
+  const readPreference = getReadPreference(cmd, options);
+  // Set the optional batchSize
+  cursorState.batchSize = cmd.batchSize || cursorState.batchSize;
+
+  // Get name of database
+  const parts = ns.split(/\./);
+  const $db = parts.shift();
+
+  // Build actual find command
+  let findCmd = { $db, find: parts.join('.') };
+
+  // I we provided a filter
+  if (cmd.query) {
+    findCmd.filter = cmd.query['$query'] || cmd.query;
+  }
+
+  [
+    'fields',
+    'hint',
+    'skip',
+    'limit',
+    'comment',
+    'maxScan',
+    'maxTimeMS',
+    'min',
+    'max',
+    'returnKey',
+    'showDiskLoc',
+    'snapshot',
+    'tailable',
+    'oplogReplay',
+    'noCursorTimeout',
+    'collation'
+  ].forEach(key => {
+    if (cmd[key]) {
+      findCmd[key] = cmd[key];
+    }
+  });
+
+  const sort = parseSortField(cmd.sort);
+
+  // Add sort to command
+  if (sort) findCmd.sort = sort;
+
+  // If we have awaitData set
+  if (cmd.awaitData) findCmd.awaitData = cmd.awaitData;
+  if (cmd.awaitdata) findCmd.awaitData = cmd.awaitdata;
+
+  // If we have explain, we need to rewrite the find command
+  // to wrap it in the explain command
+  if (cmd.explain) {
+    findCmd = {
+      explain: findCmd
+    };
+  }
+
+  // Did we provide a readConcern
+  if (cmd.readConcern) findCmd.readConcern = cmd.readConcern;
+
+  // Set up the serialize and ignoreUndefined fields
+  const serializeFunctions =
+    typeof options.serializeFunctions === 'boolean' ? options.serializeFunctions : false;
+  const ignoreUndefined =
+    typeof options.ignoreUndefined === 'boolean' ? options.ignoreUndefined : false;
+
+  // We have a Mongos topology, check if we need to add a readPreference
+  if (topology.type === 'mongos' && readPreference && readPreference.preference !== 'primary') {
+    findCmd = {
+      $query: findCmd,
+      $readPreference: readPreference.toJSON()
+    };
+  }
+
+  return new Msg(bson, findCmd, { serializeFunctions, ignoreUndefined, checkKeys: false });
+}
+
+function parseSortField(sort) {
+  if (!Array.isArray(sort)) {
+    return sort;
+  }
+
+  // Handle issue of sort being an Array
+  const sortObject = {};
+
+  if (sort.length > 0 && !Array.isArray(sort[0])) {
+    var sortDirection = sort[1];
+    // Translate the sort order text
+    if (sortDirection === 'asc') {
+      sortDirection = 1;
+    } else if (sortDirection === 'desc') {
+      sortDirection = -1;
+    }
+
+    // Set the sort order
+    sortObject[sort[0]] = sortDirection;
+  } else {
+    for (var i = 0; i < sort.length; i++) {
+      sortDirection = sort[i][1];
+      // Translate the sort order text
+      if (sortDirection === 'asc') {
+        sortDirection = 1;
+      } else if (sortDirection === 'desc') {
+        sortDirection = -1;
+      }
+
+      // Set the sort order
+      sortObject[sort[i][0]] = sortDirection;
+    }
+  }
+
+  return sortObject;
+}
+
+module.exports = executeFind;

--- a/lib/wireprotocol/3_6_support/execute_find.js
+++ b/lib/wireprotocol/3_6_support/execute_find.js
@@ -3,7 +3,7 @@
 const getReadPreference = require('../shared').getReadPreference;
 const Msg = require('../../connection/msg').Msg;
 
-function executeFind(bson, ns, cmd, cursorState, topology, options) {
+function executeFind(bson, ns, cmd, cursorState, options) {
   // Ensure we have at least some options
   options = options || {};
   // Set the optional batchSize

--- a/lib/wireprotocol/3_6_support/execute_find.js
+++ b/lib/wireprotocol/3_6_support/execute_find.js
@@ -15,7 +15,7 @@ function executeFind(bson, ns, cmd, cursorState, options) {
   const $readPreference = getReadPreference(cmd, options).toJSON();
 
   // Build actual find command
-  let findCmd = { $db, $readPreference, find: parts.join('.') };
+  let findCmd = { find: parts.join('.'), $db, $readPreference };
 
   // I we provided a filter
   if (cmd.query) {
@@ -38,12 +38,32 @@ function executeFind(bson, ns, cmd, cursorState, options) {
     'tailable',
     'oplogReplay',
     'noCursorTimeout',
+    'partial',
     'collation'
   ].forEach(key => {
     if (cmd[key]) {
       findCmd[key] = cmd[key];
     }
   });
+
+  // Check if we wish to have a singleBatch
+  if (cmd.limit < 0) {
+    findCmd.limit = Math.abs(cmd.limit);
+    findCmd.singleBatch = true;
+  }
+
+  // Add a batchSize
+  if (typeof cmd.batchSize === 'number') {
+    if (cmd.batchSize < 0) {
+      if (cmd.limit !== 0 && Math.abs(cmd.batchSize) < Math.abs(cmd.limit)) {
+        findCmd.limit = Math.abs(cmd.batchSize);
+      }
+
+      findCmd.singleBatch = true;
+    }
+
+    findCmd.batchSize = Math.abs(cmd.batchSize);
+  }
 
   const sort = parseSortField(cmd.sort);
 

--- a/lib/wireprotocol/3_6_support/execute_find.js
+++ b/lib/wireprotocol/3_6_support/execute_find.js
@@ -6,17 +6,16 @@ const Msg = require('../../connection/msg').Msg;
 function executeFind(bson, ns, cmd, cursorState, topology, options) {
   // Ensure we have at least some options
   options = options || {};
-  // Get the readPreference
-  const readPreference = getReadPreference(cmd, options);
   // Set the optional batchSize
   cursorState.batchSize = cmd.batchSize || cursorState.batchSize;
 
   // Get name of database
   const parts = ns.split(/\./);
   const $db = parts.shift();
+  const $readPreference = getReadPreference(cmd, options).toJSON();
 
   // Build actual find command
-  let findCmd = { $db, find: parts.join('.') };
+  let findCmd = { $db, $readPreference, find: parts.join('.') };
 
   // I we provided a filter
   if (cmd.query) {
@@ -71,14 +70,6 @@ function executeFind(bson, ns, cmd, cursorState, topology, options) {
     typeof options.serializeFunctions === 'boolean' ? options.serializeFunctions : false;
   const ignoreUndefined =
     typeof options.ignoreUndefined === 'boolean' ? options.ignoreUndefined : false;
-
-  // We have a Mongos topology, check if we need to add a readPreference
-  if (topology.type === 'mongos' && readPreference && readPreference.preference !== 'primary') {
-    findCmd = {
-      $query: findCmd,
-      $readPreference: readPreference.toJSON()
-    };
-  }
 
   return new Msg(bson, findCmd, { serializeFunctions, ignoreUndefined, checkKeys: false });
 }

--- a/lib/wireprotocol/3_6_support/execute_get_more.js
+++ b/lib/wireprotocol/3_6_support/execute_get_more.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const Msg = require('../../connection/msg').Msg;
+const errors = require('../../error');
+const MongoError = errors.MongoError;
+const MongoNetworkError = errors.MongoNetworkError;
+const retrieveBSON = require('../../connection/utils').retrieveBSON;
+
+const BSON = retrieveBSON();
+
+function executeGetMore(bson, ns, cursorState, batchSize, raw, connection, options, callback) {
+  options = options || {};
+  // Build command namespace
+  const parts = ns.split(/\./);
+
+  // database name
+  const $db = parts.shift();
+
+  // Create getMore command
+  var getMoreCmd = {
+    $db,
+    getMore: cursorState.cursorId,
+    collection: parts.join('.'),
+    batchSize: Math.abs(batchSize)
+  };
+
+  if (cursorState.cmd.tailable && typeof cursorState.cmd.maxAwaitTimeMS === 'number') {
+    getMoreCmd.maxTimeMS = cursorState.cmd.maxAwaitTimeMS;
+  }
+
+  // Build Query object
+  const msg = new Msg(bson, getMoreCmd, { checkKeys: false });
+
+  // Query callback
+  const queryCallback = function(err, result) {
+    if (err) return callback(err);
+    // Get the raw message
+    var r = result.message;
+
+    // If we have a timed out query or a cursor that was killed
+    if ((r.responseFlags & (1 << 0)) !== 0) {
+      return callback(new MongoNetworkError('cursor killed or timed out'), null);
+    }
+
+    // Raw, return all the extracted documents
+    if (raw) {
+      cursorState.documents = r.documents;
+      cursorState.cursorId = r.cursorId;
+      return callback(null, r.documents);
+    }
+
+    // We have an error detected
+    if (r.documents[0].ok === 0) {
+      return callback(new MongoError(r.documents[0]));
+    }
+
+    // Ensure we have a Long valid cursor id
+    var cursorId =
+      typeof r.documents[0].cursor.id === 'number'
+        ? BSON.Long.fromNumber(r.documents[0].cursor.id)
+        : r.documents[0].cursor.id;
+
+    // Set all the values
+    cursorState.documents = r.documents[0].cursor.nextBatch;
+    cursorState.cursorId = cursorId;
+
+    // Return the result
+    callback(null, r.documents[0], r.connection);
+  };
+
+  // Query options
+  const queryOptions = { command: true };
+
+  // If we have a raw query decorate the function
+  if (raw) {
+    queryOptions.raw = raw;
+  }
+
+  // Add the result field needed
+  queryOptions.documentsReturnedIn = 'nextBatch';
+
+  // Check if we need to promote longs
+  if (typeof cursorState.promoteLongs === 'boolean') {
+    queryOptions.promoteLongs = cursorState.promoteLongs;
+  }
+
+  if (typeof cursorState.promoteValues === 'boolean') {
+    queryOptions.promoteValues = cursorState.promoteValues;
+  }
+
+  if (typeof cursorState.promoteBuffers === 'boolean') {
+    queryOptions.promoteBuffers = cursorState.promoteBuffers;
+  }
+
+  if (typeof cursorState.session === 'object') {
+    queryOptions.session = cursorState.session;
+  }
+
+  // Write out the getMore command
+  connection.write(msg, queryOptions, queryCallback);
+}
+
+module.exports = executeGetMore;

--- a/lib/wireprotocol/3_6_support/execute_get_more.js
+++ b/lib/wireprotocol/3_6_support/execute_get_more.js
@@ -8,8 +8,7 @@ const retrieveBSON = require('../../connection/utils').retrieveBSON;
 
 const BSON = retrieveBSON();
 
-function executeGetMore(bson, ns, cursorState, batchSize, raw, connection, options, callback) {
-  options = options || {};
+function executeGetMore(bson, ns, cursorState, batchSize, raw, connection, callback) {
   // Build command namespace
   const parts = ns.split(/\./);
 

--- a/lib/wireprotocol/3_6_support/execute_get_more.js
+++ b/lib/wireprotocol/3_6_support/execute_get_more.js
@@ -17,10 +17,10 @@ function executeGetMore(bson, ns, cursorState, batchSize, raw, connection, callb
 
   // Create getMore command
   var getMoreCmd = {
-    $db,
     getMore: cursorState.cursorId,
     collection: parts.join('.'),
-    batchSize: Math.abs(batchSize)
+    batchSize: Math.abs(batchSize),
+    $db
   };
 
   if (cursorState.cmd.tailable && typeof cursorState.cmd.maxAwaitTimeMS === 'number') {

--- a/lib/wireprotocol/3_6_support/execute_kill_cursor.js
+++ b/lib/wireprotocol/3_6_support/execute_kill_cursor.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const Msg = require('../../connection/msg').Msg;
+const errors = require('../../error');
+const MongoError = errors.MongoError;
+const MongoNetworkError = errors.MongoNetworkError;
+
+function executeKillCursor(bson, ns, cursorState, pool, callback) {
+  // Build command namespace
+  const parts = ns.split(/\./);
+  const $db = parts.shift();
+  const cursorId = cursorState.cursorId;
+
+  const killcursorCmd = {
+    killCursors: parts.join('.'),
+    cursors: [cursorId],
+    $db
+  };
+
+  const msg = new Msg(bson, killcursorCmd, { checkKeys: false });
+
+  // Kill cursor callback
+  const killCursorCallback = (err, result) => {
+    if (err) {
+      return evaluatePotentialCallback(callback, err);
+    }
+
+    // Result
+    const r = result.message;
+    // If we have a timed out query or a cursor that was killed
+    if ((r.responseFlags & (1 << 0)) !== 0) {
+      return evaluatePotentialCallback(
+        callback,
+        new MongoNetworkError('cursor killed or timed out'),
+        null
+      );
+    }
+
+    if (!Array.isArray(r.documents) || r.documents.length === 0) {
+      return evaluatePotentialCallback(
+        callback,
+        new MongoError(`invalid killCursors result returned for cursor id ${cursorId}`)
+      );
+    }
+
+    evaluatePotentialCallback(callback, null, r.documents[0]);
+  };
+
+  const options = { command: true };
+  if (typeof cursorState.session === 'object') {
+    options.session = cursorState.session;
+  }
+
+  if (!(pool && pool.isConnected())) {
+    return evaluatePotentialCallback(callback, null, null);
+  }
+
+  try {
+    pool.write(msg, options, killCursorCallback);
+  } catch (err) {
+    killCursorCallback(err, null);
+  }
+}
+
+function evaluatePotentialCallback(cb, err, payload) {
+  if (typeof cb === 'function') {
+    return cb(err, payload);
+  }
+}
+
+module.exports = executeKillCursor;

--- a/lib/wireprotocol/3_6_support/execute_write.js
+++ b/lib/wireprotocol/3_6_support/execute_write.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const Msg = require('../../connection/msg').Msg;
+const errors = require('../../error');
+const MongoError = errors.MongoError;
+
+function executeWrite(pool, bson, type, opsField, ns, ops, options, callback) {
+  if (!(Array.isArray(ops) && ops.length)) {
+    throw new MongoError('write operation must contain at least one document');
+  }
+
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  options = options || {};
+
+  // Split the ns up to get db and collection
+  const p = ns.split('.');
+  const $db = p.shift();
+  // Options
+  const ordered = typeof options.ordered === 'boolean' ? options.ordered : true;
+  const writeConcern = options.writeConcern;
+
+  // return skeleton
+  const writeCommand = { $db, ordered };
+  writeCommand[type] = p.join('.');
+  writeCommand[opsField] = ops;
+
+  // Did we specify a write concern
+  if (writeConcern && Object.keys(writeConcern).length > 0) {
+    writeCommand.writeConcern = writeConcern;
+  }
+
+  // If we have collation passed in
+  if (options.collation) {
+    for (let i = 0; i < writeCommand[opsField].length; i++) {
+      if (!writeCommand[opsField][i].collation) {
+        writeCommand[opsField][i].collation = options.collation;
+      }
+    }
+  }
+
+  // Do we have bypassDocumentValidation set, then enable it on the write command
+  if (typeof options.bypassDocumentValidation === 'boolean') {
+    writeCommand.bypassDocumentValidation = options.bypassDocumentValidation;
+  }
+
+  // optionally add a `txnNumber` if retryable writes are being attempted
+  if (typeof options.txnNumber !== 'undefined') {
+    writeCommand.txnNumber = options.txnNumber;
+  }
+
+  // Options object
+  const opts = { command: true };
+  if (typeof options.session !== 'undefined') opts.session = options.session;
+  var queryOptions = { checkKeys: false };
+  if (type === 'insert') queryOptions.checkKeys = false;
+  if (typeof options.checkKeys === 'boolean') queryOptions.checkKeys = options.checkKeys;
+
+  // Ensure we support serialization of functions
+  if (options.serializeFunctions) queryOptions.serializeFunctions = options.serializeFunctions;
+  // Do not serialize the undefined fields
+  if (options.ignoreUndefined) queryOptions.ignoreUndefined = options.ignoreUndefined;
+
+  try {
+    // Create write command
+    const cmd = new Msg(bson, writeCommand, queryOptions);
+    // Execute command
+    pool.write(cmd, opts, callback);
+  } catch (err) {
+    callback(err);
+  }
+}
+
+module.exports = executeWrite;

--- a/lib/wireprotocol/3_6_support/execute_write.js
+++ b/lib/wireprotocol/3_6_support/execute_write.js
@@ -4,6 +4,8 @@ const Msg = require('../../connection/msg').Msg;
 const errors = require('../../error');
 const MongoError = errors.MongoError;
 
+const noop = () => {};
+
 function executeWrite(pool, bson, type, opsField, ns, ops, options, callback) {
   if (!(Array.isArray(ops) && ops.length)) {
     throw new MongoError('write operation must contain at least one document');
@@ -74,7 +76,11 @@ function executeWrite(pool, bson, type, opsField, ns, ops, options, callback) {
     // Create write command
     const cmd = new Msg(bson, writeCommand, queryOptions);
     // Execute command
-    pool.write(cmd, opts, callback);
+    pool.write(cmd, opts, moreToCome ? () => noop : callback);
+
+    if (moreToCome) {
+      callback(null, { result: { ok: 1 } });
+    }
   } catch (err) {
     callback(err);
   }

--- a/lib/wireprotocol/3_6_support/execute_write.js
+++ b/lib/wireprotocol/3_6_support/execute_write.js
@@ -24,9 +24,11 @@ function executeWrite(pool, bson, type, opsField, ns, ops, options, callback) {
   const writeConcern = options.writeConcern;
 
   // return skeleton
-  const writeCommand = { $db, ordered };
+  const writeCommand = {};
   writeCommand[type] = p.join('.');
   writeCommand[opsField] = ops;
+  writeCommand.$db = $db;
+  writeCommand.ordered = ordered;
 
   let moreToCome = false;
   // Did we specify a write concern

--- a/lib/wireprotocol/3_6_support/execute_write.js
+++ b/lib/wireprotocol/3_6_support/execute_write.js
@@ -28,9 +28,13 @@ function executeWrite(pool, bson, type, opsField, ns, ops, options, callback) {
   writeCommand[type] = p.join('.');
   writeCommand[opsField] = ops;
 
+  let moreToCome = false;
   // Did we specify a write concern
   if (writeConcern && Object.keys(writeConcern).length > 0) {
     writeCommand.writeConcern = writeConcern;
+    if (writeConcern.w === 0) {
+      moreToCome = true;
+    }
   }
 
   // If we have collation passed in
@@ -55,7 +59,7 @@ function executeWrite(pool, bson, type, opsField, ns, ops, options, callback) {
   // Options object
   const opts = { command: true };
   if (typeof options.session !== 'undefined') opts.session = options.session;
-  var queryOptions = { checkKeys: false };
+  var queryOptions = { moreToCome, checkKeys: false };
   if (type === 'insert') queryOptions.checkKeys = false;
   if (typeof options.checkKeys === 'boolean') queryOptions.checkKeys = options.checkKeys;
 

--- a/lib/wireprotocol/3_6_support/index.js
+++ b/lib/wireprotocol/3_6_support/index.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const executeWrite = require('./execute_write');
+const executeFind = require('./execute_find');
+const executeKillCursor = require('./execute_kill_cursor');
+const executeGetMore = require('./execute_get_more');
+const setupCommand = require('./setup_command');
+
+const errors = require('../../error');
+const MongoError = errors.MongoError;
+
+class WireProtocol {
+  constructor() {}
+
+  insert(pool, ismaster, ns, bson, ops, options, callback) {
+    executeWrite(pool, bson, 'insert', 'documents', ns, ops, options, callback);
+  }
+
+  update(pool, ismaster, ns, bson, ops, options, callback) {
+    executeWrite(pool, bson, 'update', 'updates', ns, ops, options, callback);
+  }
+
+  remove(pool, ismaster, ns, bson, ops, options, callback) {
+    executeWrite(pool, bson, 'delete', 'deletes', ns, ops, options, callback);
+  }
+
+  killCursor(bson, ns, cursorState, pool, callback) {
+    executeKillCursor(bson, ns, cursorState, pool, callback);
+  }
+
+  getMore(bson, ns, cursorState, batchSize, raw, connection, options, callback) {
+    executeGetMore(bson, ns, cursorState, batchSize, raw, connection, options, callback);
+  }
+
+  command(bson, ns, cmd, cursorState, topology, options) {
+    options = options || {};
+    // Check if this is a wire protocol command or not
+    const wireProtocolCommand =
+      typeof options.wireProtocolCommand === 'boolean' ? options.wireProtocolCommand : true;
+
+    // Establish type of command
+    if (cmd.find && wireProtocolCommand) {
+      // Create the find command
+      const query = executeFind(bson, ns, cmd, cursorState, topology, options);
+      // Mark the cmd as virtual
+      cmd.virtual = false;
+      // Signal the documents are in the firstBatch value
+      query.documentsReturnedIn = 'firstBatch';
+      // Return the query
+      return query;
+    } else if (cursorState.cursorId != null) {
+      return;
+    } else if (cmd) {
+      return setupCommand(bson, ns, cmd, cursorState, topology, options);
+    }
+
+    throw new MongoError(`command ${JSON.stringify(cmd)} does not return a cursor`);
+  }
+}
+
+module.exports = WireProtocol;

--- a/lib/wireprotocol/3_6_support/index.js
+++ b/lib/wireprotocol/3_6_support/index.js
@@ -29,7 +29,7 @@ class WireProtocol {
   }
 
   getMore(bson, ns, cursorState, batchSize, raw, connection, options, callback) {
-    executeGetMore(bson, ns, cursorState, batchSize, raw, connection, options, callback);
+    executeGetMore(bson, ns, cursorState, batchSize, raw, connection, callback);
   }
 
   command(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/3_6_support/index.js
+++ b/lib/wireprotocol/3_6_support/index.js
@@ -51,7 +51,7 @@ class WireProtocol {
     } else if (cursorState.cursorId != null) {
       return;
     } else if (cmd) {
-      return setupCommand(bson, ns, cmd, cursorState, topology, options);
+      return setupCommand(bson, ns, cmd, options);
     }
 
     throw new MongoError(`command ${JSON.stringify(cmd)} does not return a cursor`);

--- a/lib/wireprotocol/3_6_support/index.js
+++ b/lib/wireprotocol/3_6_support/index.js
@@ -41,7 +41,7 @@ class WireProtocol {
     // Establish type of command
     if (cmd.find && wireProtocolCommand) {
       // Create the find command
-      const query = executeFind(bson, ns, cmd, cursorState, topology, options);
+      const query = executeFind(bson, ns, cmd, cursorState, options);
       // Mark the cmd as virtual
       cmd.virtual = false;
       // Signal the documents are in the firstBatch value

--- a/lib/wireprotocol/3_6_support/setup_command.js
+++ b/lib/wireprotocol/3_6_support/setup_command.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const getReadPreference = require('../shared').getReadPreference;
+const Msg = require('../../connection/msg').Msg;
+
+function setupCommand(bson, ns, cmd, cursorState, topology, options) {
+  // Set empty options object
+  options = options || {};
+  // Get the readPreference
+  const readPreference = getReadPreference(cmd, options);
+
+  // Final query
+  let finalCmd = {};
+  for (let name in cmd) {
+    finalCmd[name] = cmd[name];
+  }
+
+  // Build add db to command
+  const parts = ns.split(/\./);
+  finalCmd.$db = parts.shift();
+
+  // Serialize functions
+  const serializeFunctions =
+    typeof options.serializeFunctions === 'boolean' ? options.serializeFunctions : false;
+
+  // Set up the serialize and ignoreUndefined fields
+  const ignoreUndefined =
+    typeof options.ignoreUndefined === 'boolean' ? options.ignoreUndefined : false;
+
+  // We have a Mongos topology, check if we need to add a readPreference
+  if (topology.type === 'mongos' && readPreference && readPreference.preference !== 'primary') {
+    finalCmd = {
+      $query: finalCmd,
+      $readPreference: readPreference.toJSON()
+    };
+  }
+
+  return new Msg(bson, finalCmd, { serializeFunctions, ignoreUndefined, checkKeys: false });
+}
+
+module.exports = setupCommand;

--- a/lib/wireprotocol/3_6_support/setup_command.js
+++ b/lib/wireprotocol/3_6_support/setup_command.js
@@ -6,8 +6,6 @@ const Msg = require('../../connection/msg').Msg;
 function setupCommand(bson, ns, cmd, cursorState, topology, options) {
   // Set empty options object
   options = options || {};
-  // Get the readPreference
-  const readPreference = getReadPreference(cmd, options);
 
   // Final query
   let finalCmd = {};
@@ -18,6 +16,7 @@ function setupCommand(bson, ns, cmd, cursorState, topology, options) {
   // Build add db to command
   const parts = ns.split(/\./);
   finalCmd.$db = parts.shift();
+  finalCmd.$readPreference = getReadPreference(cmd, options).toJSON();
 
   // Serialize functions
   const serializeFunctions =
@@ -26,14 +25,6 @@ function setupCommand(bson, ns, cmd, cursorState, topology, options) {
   // Set up the serialize and ignoreUndefined fields
   const ignoreUndefined =
     typeof options.ignoreUndefined === 'boolean' ? options.ignoreUndefined : false;
-
-  // We have a Mongos topology, check if we need to add a readPreference
-  if (topology.type === 'mongos' && readPreference && readPreference.preference !== 'primary') {
-    finalCmd = {
-      $query: finalCmd,
-      $readPreference: readPreference.toJSON()
-    };
-  }
 
   return new Msg(bson, finalCmd, { serializeFunctions, ignoreUndefined, checkKeys: false });
 }

--- a/lib/wireprotocol/3_6_support/setup_command.js
+++ b/lib/wireprotocol/3_6_support/setup_command.js
@@ -3,7 +3,7 @@
 const getReadPreference = require('../shared').getReadPreference;
 const Msg = require('../../connection/msg').Msg;
 
-function setupCommand(bson, ns, cmd, cursorState, topology, options) {
+function setupCommand(bson, ns, cmd, options) {
   // Set empty options object
   options = options || {};
 

--- a/lib/wireprotocol/shared.js
+++ b/lib/wireprotocol/shared.js
@@ -15,7 +15,8 @@ var opcodes = {
   OP_GETMORE: 2005,
   OP_DELETE: 2006,
   OP_KILL_CURSORS: 2007,
-  OP_COMPRESSED: 2012
+  OP_COMPRESSED: 2012,
+  OP_MSG: 2013
 };
 
 var getReadPreference = function(cmd, options) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "mongodb-mock-server": "^1.0.0",
     "mongodb-test-runner": "^1.1.18",
     "prettier": "^1.6.1",
+    "sinon": "^4.2.2",
+    "sinon-chai": "^2.14.0",
     "snappy": "^6.0.1"
   },
   "peerOptionalDependencies": {

--- a/test/tests/unit/wireprotocol/3_6/find_tests.js
+++ b/test/tests/unit/wireprotocol/3_6/find_tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const expect = require('chai').expect;
 const TestHarness = require('./utils').TestHarness;
+const expectMsgToHaveSingleQuery = require('./utils').expectMsgToHaveSingleQuery;
 const executeFind = require('../../../../../lib/wireprotocol/3_6_support/execute_find');
 const ReadPreference = require('../../../../../lib/topologies/read_preference');
 
@@ -11,15 +11,6 @@ describe('Wire Protocol 3.6 Find', function() {
   const $db = 'darmok';
   const collection = 'jalad';
   const namespace = `${$db}.${collection}`;
-
-  function expectMsgToHaveSingleQuery(msg) {
-    return expect(msg)
-      .to.have.property('query')
-      .that.is.an('array')
-      .with.lengthOf(1)
-      .that.has.property(0)
-      .that.is.an('object');
-  }
 
   it('should properly parse out namespace and readPreference', function() {
     const readPreference = new ReadPreference('secondary');

--- a/test/tests/unit/wireprotocol/3_6/find_tests.js
+++ b/test/tests/unit/wireprotocol/3_6/find_tests.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const expect = require('chai').expect;
+const TestHarness = require('./utils').TestHarness;
+const executeFind = require('../../../../../lib/wireprotocol/3_6_support/execute_find');
+const ReadPreference = require('../../../../../lib/topologies/read_preference');
+
+describe('Wire Protocol 3.6 Find', function() {
+  const test = new TestHarness();
+
+  const $db = 'darmok';
+  const collection = 'jalad';
+  const namespace = `${$db}.${collection}`;
+
+  function expectMsgToHaveSingleQuery(msg) {
+    return expect(msg)
+      .to.have.property('query')
+      .that.is.an('array')
+      .with.lengthOf(1)
+      .that.has.property(0)
+      .that.is.an('object');
+  }
+
+  it('should properly parse out namespace and readPreference', function() {
+    const readPreference = new ReadPreference('secondary');
+
+    const cmd = {
+      readPreference,
+      query: {
+        shaka: 'when the walls fell'
+      }
+    };
+
+    const msg = executeFind(test.bson, namespace, cmd, {}, {});
+
+    expectMsgToHaveSingleQuery(msg).that.deep.includes({
+      $db,
+      $readPreference: readPreference.toJSON(),
+      find: collection,
+      filter: cmd.query
+    });
+  });
+
+  it('will attach a sort object to the command', function() {
+    const cmd = {
+      query: {},
+      sort: {
+        a: 1,
+        b: -1
+      }
+    };
+    const msg = executeFind(test.bson, namespace, cmd, {}, {});
+
+    expectMsgToHaveSingleQuery(msg)
+      .that.has.property('sort')
+      .that.equals(cmd.sort);
+  });
+
+  it('will attach a sort array to the command as a sort object', function() {
+    const cmd = {
+      query: {},
+      sort: ['foo', 'asc']
+    };
+    const msg = executeFind(test.bson, namespace, cmd, {}, {});
+
+    expectMsgToHaveSingleQuery(msg)
+      .that.has.property('sort')
+      .that.deep.equals({ foo: 1 });
+  });
+
+  it('will attach a sort array of arrays to the command as a sort object', function() {
+    const cmd = {
+      query: {},
+      sort: [['foo', 'desc'], ['bar', 1], ['fizz', -1], ['buzz', 'asc']]
+    };
+    const msg = executeFind(test.bson, namespace, cmd, {}, {});
+
+    expectMsgToHaveSingleQuery(msg)
+      .that.has.property('sort')
+      .that.deep.equals({ foo: -1, bar: 1, fizz: -1, buzz: 1 });
+  });
+
+  it('should wrap the entire command when explain is passed in', function() {
+    const cmd = {
+      query: { a: 1, b: 1 },
+      sort: { a: -1 },
+      explain: true
+    };
+    const msg = executeFind(test.bson, namespace, cmd, {}, {});
+
+    expectMsgToHaveSingleQuery(msg)
+      .that.includes.property('explain')
+      .that.deep.includes({
+        $db,
+        find: collection,
+        filter: cmd.query,
+        sort: cmd.sort
+      });
+  });
+
+  [
+    'fields',
+    'hint',
+    'skip',
+    'limit',
+    'comment',
+    'maxScan',
+    'maxTimeMS',
+    'min',
+    'max',
+    'returnKey',
+    'showDiskLoc',
+    'snapshot',
+    'tailable',
+    'oplogReplay',
+    'noCursorTimeout',
+    'collation'
+  ].forEach(option => {
+    it(`should include the option ${option} if it is passed in on the command`, function() {
+      const cmd = {
+        query: { a: 1, b: 1 },
+        [option]: true
+      };
+      const msg = executeFind(test.bson, namespace, cmd, {}, {});
+
+      expectMsgToHaveSingleQuery(msg).that.includes.property(option, true);
+    });
+  });
+});

--- a/test/tests/unit/wireprotocol/3_6/get_more_tests.js
+++ b/test/tests/unit/wireprotocol/3_6/get_more_tests.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const expect = require('chai').expect;
+const TestHarness = require('./utils').TestHarness;
+const expectMsgToHaveSingleQuery = require('./utils').expectMsgToHaveSingleQuery;
+const executeGetMore = require('../../../../../lib/wireprotocol/3_6_support/execute_get_more');
+
+describe('Wire Protocol 3.6 GetMore', function() {
+  const test = new TestHarness();
+
+  const $db = 'darmok';
+  const collection = 'jalad';
+  const namespace = `${$db}.${collection}`;
+
+  let connection;
+
+  beforeEach(() => {
+    connection = { write: test.sinon.stub() };
+  });
+
+  it('should reflect the basic options on to the getMoreCommand', function() {
+    const cursorState = {
+      cmd: {},
+      cursorId: 8675309
+    };
+
+    const BATCH_SIZE = -23000;
+
+    executeGetMore(
+      test.bson,
+      namespace,
+      cursorState,
+      BATCH_SIZE,
+      undefined,
+      connection,
+      test.callback
+    );
+
+    expect(connection.write).to.have.been.calledOnce;
+
+    expectMsgToHaveSingleQuery(connection.write.lastCall.args[0]).to.deep.equal({
+      $db,
+      collection,
+      batchSize: 23000,
+      getMore: cursorState.cursorId
+    });
+  });
+
+  it('should attach maxTimeMS', function() {
+    const cursorState = {
+      cmd: {
+        tailable: true,
+        maxAwaitTimeMS: 1001
+      },
+      cursorId: 8675309
+    };
+
+    const BATCH_SIZE = -23000;
+
+    executeGetMore(
+      test.bson,
+      namespace,
+      cursorState,
+      BATCH_SIZE,
+      undefined,
+      connection,
+      test.callback
+    );
+
+    expect(connection.write).to.have.been.calledOnce;
+
+    expectMsgToHaveSingleQuery(connection.write.lastCall.args[0]).to.deep.equal({
+      $db,
+      collection,
+      batchSize: 23000,
+      getMore: cursorState.cursorId,
+      maxTimeMS: cursorState.cmd.maxAwaitTimeMS
+    });
+  });
+
+  describe('callback tests', function() {
+    let queryCallback;
+
+    beforeEach(() => {
+      const cursorState = {
+        cmd: {
+          tailable: true,
+          maxAwaitTimeMS: 1001
+        },
+        cursorId: 8675309
+      };
+
+      const BATCH_SIZE = -23000;
+
+      executeGetMore(
+        test.bson,
+        namespace,
+        cursorState,
+        BATCH_SIZE,
+        undefined,
+        connection,
+        test.callback
+      );
+
+      queryCallback = connection.write.lastCall.args[2];
+    });
+
+    it('should pass along any errors to the callback', function() {
+      const err = new Error('test error 1');
+      queryCallback(err);
+
+      expect(test.callback).to.have.been.calledOnce.and.calledWithExactly(err);
+    });
+
+    it('should throw MongoNetworkError if responseFlag is nonzero', function() {
+      const err = null;
+      const response = {
+        message: {
+          documents: undefined,
+          responseFlags: 1
+        }
+      };
+
+      queryCallback(err, response);
+
+      expect(test.callback).to.have.been.calledOnce;
+
+      const returnedError = test.callback.lastCall.args[0];
+
+      expect(returnedError)
+        .to.be.an.instanceOf(test.MongoNetworkError)
+        .and.to.have.property('message')
+        .that.equals('cursor killed or timed out');
+    });
+
+    it('should return a MongoError if ok is 0', function() {
+      const err = null;
+      const badMsg = { ok: 0 };
+      const response = {
+        message: {
+          documents: [badMsg]
+        }
+      };
+
+      queryCallback(err, response);
+
+      expect(test.callback).to.have.been.calledOnce;
+
+      const returnedError = test.callback.lastCall.args[0];
+
+      expect(returnedError)
+        .to.be.an.instanceOf(test.MongoError)
+        .and.to.have.property('message')
+        .that.equals('n/a');
+    });
+
+    it('should return a valid document and connection to the callback', function() {
+      const validDoc = { ok: 1, cursor: { id: 8675309 } };
+      const err = null;
+      const response = {
+        message: {
+          documents: [validDoc],
+          connection: {}
+        }
+      };
+
+      queryCallback(err, response);
+
+      expect(test.callback).to.have.been.calledOnce.and.to.have.been.calledWithExactly(
+        null,
+        response.message.documents[0],
+        response.message.connection
+      );
+    });
+  });
+});

--- a/test/tests/unit/wireprotocol/3_6/kill_cursor_tests.js
+++ b/test/tests/unit/wireprotocol/3_6/kill_cursor_tests.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const expect = require('chai').expect;
+const makeSinonSandbox = require('./utils').makeSinonSandbox;
+const errors = require('../../../../../lib/error');
+const MongoError = errors.MongoError;
+const MongoNetworkError = errors.MongoNetworkError;
+const executeKillCursor = require('../../../../../lib/wireprotocol/3_6_support/execute_kill_cursor');
+const Pool = require('../../../../../lib/connection/pool');
+const BSON = require('bson');
+
+describe('Wire Protocol 3.6 Kill Cursor', function() {
+  const sinon = makeSinonSandbox();
+  let bson, pool, callback;
+
+  const $db = 'darmok';
+  const collection = 'jalad';
+  const namespace = `${$db}.${collection}`;
+
+  const cursorState = {
+    cursorId: 8675309
+  };
+
+  beforeEach(() => {
+    bson = sinon.createStubInstance(BSON);
+    pool = sinon.createStubInstance(Pool);
+    pool.isConnected.returns(true);
+    callback = sinon.stub();
+  });
+
+  it('should not call to pool if pool is not there, or pool is not connected', function() {
+    executeKillCursor(bson, namespace, cursorState, undefined, callback);
+    expect(pool.write).to.not.have.been.called;
+    expect(callback).to.have.been.calledOnce.and.calledWithExactly(null, null);
+    callback.reset();
+
+    pool.isConnected.returns(false);
+
+    executeKillCursor(bson, namespace, cursorState, pool, callback);
+    expect(pool.write).to.not.have.been.called;
+    expect(callback).to.have.been.calledOnce.and.calledWithExactly(null, null);
+  });
+
+  it('should catch any errors throw by pool.write, and pass them along to callback', function() {
+    const err = new Error('this is a test error');
+    pool.write.throws(err);
+
+    expect(() => executeKillCursor(bson, namespace, cursorState, pool, callback)).to.not.throw();
+
+    expect(callback).to.have.been.calledOnce.and.calledWithExactly(err, undefined);
+  });
+
+  it('should properly format command for killing cursor', function() {
+    executeKillCursor(bson, namespace, cursorState, pool, callback);
+
+    expect(pool.write).to.have.been.calledOnce.and.calledWithExactly(
+      sinon.match({ query: sinon.match.any }),
+      sinon.match.object,
+      sinon.match.func
+    );
+
+    const msg = pool.write.lastCall.args[0];
+
+    expect(msg)
+      .to.have.property('query')
+      .with.lengthOf(1)
+      .that.has.property(0)
+      .that.deep.includes({
+        $db,
+        cursors: [cursorState.cursorId],
+        killCursors: collection
+      });
+  });
+
+  describe('killCursorCallback', function() {
+    let killCursorCallback;
+    beforeEach(() => {
+      executeKillCursor(bson, namespace, cursorState, pool, callback);
+      killCursorCallback = pool.write.lastCall.args[2];
+    });
+
+    it('should take any errors from pool callback and pass them along', function() {
+      const err = new Error('this is a test error');
+      killCursorCallback(err);
+
+      expect(callback).to.have.been.calledOnce.and.to.have.been.calledWithExactly(err, undefined);
+    });
+
+    it('should throw MongoNetworkError if responseFlag is nonzero', function() {
+      const err = null;
+      const response = {
+        message: {
+          documents: undefined,
+          responseFlags: 1
+        }
+      };
+
+      killCursorCallback(err, response);
+
+      expect(callback).to.have.been.calledOnce;
+
+      const returnedError = callback.lastCall.args[0];
+
+      expect(returnedError)
+        .to.be.an.instanceOf(MongoNetworkError)
+        .and.to.have.property('message')
+        .that.equals('cursor killed or timed out');
+    });
+
+    it('should throw MongoError if an invalid response comes back', function() {
+      const err = null;
+      const response = {
+        message: {
+          documents: [],
+          responseFlags: 0
+        }
+      };
+
+      killCursorCallback(err, response);
+
+      expect(callback).to.have.been.calledOnce;
+
+      const returnedError = callback.lastCall.args[0];
+
+      expect(returnedError)
+        .to.be.an.instanceOf(MongoError)
+        .and.to.have.property('message')
+        .that.equals(`invalid killCursors result returned for cursor id ${cursorState.cursorId}`);
+    });
+
+    it('should return first returned document if everything is fine', function() {
+      const doc = {};
+      const err = null;
+      const response = {
+        message: {
+          documents: [doc],
+          responseFlags: 0
+        }
+      };
+
+      killCursorCallback(err, response);
+
+      expect(callback).to.have.been.calledOnce.and.to.have.been.calledWithExactly(null, doc);
+    });
+  });
+});

--- a/test/tests/unit/wireprotocol/3_6/msg_test.js
+++ b/test/tests/unit/wireprotocol/3_6/msg_test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const expect = require('chai').expect;
+const Msg = require('../../../../../lib/connection/msg').Msg;
+const BSON = require('bson');
+const shared = require('../../../../../lib/wireprotocol/shared');
+const opcodes = shared.opcodes;
+const parseOpMsg = require('./utils').parseOpMsg;
+
+describe('OP_MSG', function() {
+  let bson;
+  beforeEach(() => (bson = new BSON()));
+
+  function validateHeaderAndFlags(message) {
+    const header = message.header;
+    expect(header)
+      .to.have.property('length')
+      .that.equals(message.fullSize);
+    expect(header)
+      .to.have.property('requestId')
+      .that.is.a('number')
+      .that.is.gt(0);
+    expect(header)
+      .to.have.property('responseTo')
+      .that.equals(0);
+    expect(header)
+      .to.have.property('opCode')
+      .that.equals(opcodes.OP_MSG);
+
+    expect(message).to.have.property('flags', 0);
+  }
+
+  function testDocumentMessage(pojoMessage) {
+    const msg = new Msg(bson, pojoMessage, {});
+    const buffers = msg.toBin();
+    const parsedMessage = parseOpMsg(buffers);
+
+    validateHeaderAndFlags(parsedMessage);
+
+    expect(parsedMessage.segments)
+      .to.be.an('array')
+      .and.to.have.a.lengthOf(1);
+
+    const segment = parsedMessage.segments[0];
+
+    expect(segment.payloadType).to.equal(0);
+    expect(segment.documents).to.have.a.lengthOf(1);
+    expect(bson.serialize(pojoMessage).equals(segment.documents[0])).to.equal(true);
+  }
+
+  function testSequenceMessage(argument, pojoMessage) {
+    const msg = new Msg(bson, pojoMessage, {});
+    const buffers = msg.toBin();
+    const parsedMessage = parseOpMsg(buffers);
+
+    validateHeaderAndFlags(parsedMessage);
+    expect(parsedMessage.segments).to.have.a.lengthOf(2);
+
+    const commandSegment = parsedMessage.segments[0];
+    const documentsSegment = parsedMessage.segments[1];
+
+    expect(commandSegment.payloadType).to.equal(0);
+    const commandPojo = Object.assign({}, pojoMessage);
+    delete commandPojo[argument];
+    expect(commandSegment.documents).to.have.lengthOf(1);
+    expect(commandSegment.documents[0].equals(bson.serialize(commandPojo))).to.equal(true);
+
+    expect(documentsSegment.payloadType).to.equal(1);
+    expect(documentsSegment.argument).to.equal(argument);
+    expect(documentsSegment.documents).to.have.an.lengthOf(pojoMessage[argument].length);
+
+    documentsSegment.documents.forEach((document, index) => {
+      expect(document.equals(bson.serialize(pojoMessage[argument][index]))).to.equal(true);
+    });
+  }
+
+  describe('insert tests', function() {
+    it('should properly serialize the insert of a single document', function() {
+      testDocumentMessage({
+        insert: 'collectionName',
+        documents: [{ _id: 'Document#1', example: 1 }],
+        writeConcern: { w: 'majority' }
+      });
+    });
+
+    it('should properly serialize the insert of two documents', function() {
+      testSequenceMessage('documents', {
+        insert: 'collectionName',
+        documents: [
+          { _id: 'Document#1', example: 1 },
+          { _id: 'Document#2', example: 2 },
+          { _id: 'Document#3', example: 3 }
+        ],
+        writeConcern: { w: 'majority' }
+      });
+    });
+  });
+
+  describe('update tests', function() {
+    it('should properly serialize the update of a single document', function() {
+      testDocumentMessage({
+        update: 'collectionName',
+        updates: [
+          {
+            q: { example: 1 },
+            u: { $set: { example: 4 } }
+          }
+        ]
+      });
+    });
+
+    it('should properly serialize the update of two documents', function() {
+      testSequenceMessage('updates', {
+        update: 'collectionName',
+        updates: [
+          {
+            q: { example: 1 },
+            u: { $set: { example: 4 } }
+          },
+          {
+            q: { example: 2 },
+            u: { $set: { example: 5 } }
+          }
+        ]
+      });
+    });
+  });
+
+  describe('delete tests', function() {
+    it('should properly serialize the delete of a single document', function() {
+      testDocumentMessage({
+        delete: 'collectionName',
+        deletes: [
+          {
+            q: { example: 3 },
+            limit: 1
+          }
+        ]
+      });
+    });
+
+    it('should properly serialize the delete of two documents', function() {
+      testSequenceMessage('deletes', {
+        delete: 'collectionName',
+        deletes: [
+          {
+            q: { example: 3 },
+            limit: 1
+          },
+          {
+            q: { example: 4 },
+            limit: 1
+          }
+        ]
+      });
+    });
+  });
+
+  it.skip('should properly serialize multiple commands');
+});

--- a/test/tests/unit/wireprotocol/3_6/msg_test.js
+++ b/test/tests/unit/wireprotocol/3_6/msg_test.js
@@ -156,5 +156,13 @@ describe('OP_MSG', function() {
     });
   });
 
+  it('should properly reflect getMore flag in BSON', function() {
+    const msg = new Msg(bson, {}, { moreToCome: true });
+    const buffers = msg.toBin();
+    const parsedMessage = parseOpMsg(buffers);
+
+    expect(parsedMessage).to.have.property('flags', Msg.flags.MORE_TO_COME);
+  });
+
   it.skip('should properly serialize multiple commands');
 });

--- a/test/tests/unit/wireprotocol/3_6/setup_command_tests.js
+++ b/test/tests/unit/wireprotocol/3_6/setup_command_tests.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const TestHarness = require('./utils').TestHarness;
+const expectMsgToHaveSingleQuery = require('./utils').expectMsgToHaveSingleQuery;
+const setupCommand = require('../../../../../lib/wireprotocol/3_6_support/setup_command');
+const ReadPreference = require('../../../../../lib/topologies/read_preference');
+
+describe('Wire Protocol 3.6 Command', function() {
+  const test = new TestHarness();
+
+  const $db = 'darmok';
+  const collection = 'jalad';
+  const namespace = `${$db}.${collection}`;
+
+  it('should include all properties of a passed in command', function() {
+    const cmd = {
+      darmok: 'on the ocean',
+      tanagra: 'on the ocean',
+      raiAndJiri: 'at lunga',
+      kiteo: 'his sails unfurled'
+    };
+
+    const msg = setupCommand(test.bson, namespace, cmd);
+
+    const expectQuery = expectMsgToHaveSingleQuery(msg);
+
+    expectQuery.to.not.equal(cmd);
+    expectQuery.to.deep.include(cmd);
+  });
+
+  it('should add global fields to the command', function() {
+    const cmd = {
+      darmok: 'on the ocean',
+      tanagra: 'on the ocean',
+      raiAndJiri: 'at lunga',
+      kiteo: 'his sails unfurled',
+      readPreference: new ReadPreference('primaryPreferred')
+    };
+
+    const msg = setupCommand(test.bson, namespace, cmd);
+    expectMsgToHaveSingleQuery(msg).to.deep.include({
+      $db,
+      $readPreference: cmd.readPreference.toJSON()
+    });
+  });
+});

--- a/test/tests/unit/wireprotocol/3_6/utils.js
+++ b/test/tests/unit/wireprotocol/3_6/utils.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const chai = require('chai');
+const expect = chai.expect;
 const sinon = require('sinon');
 const BSON = require('bson');
+const Msg = require('../../../../../lib/connection/msg').Msg;
 const Pool = require('../../../../../lib/connection/pool');
 const shared = require('../../../../../lib/wireprotocol/shared');
 const errors = require('../../../../../lib/error');
@@ -85,4 +87,14 @@ function parseOpMsg(data) {
   return { header, flags, segments, fullSize: data.length, rawData: data };
 }
 
-module.exports = { parseOpMsg, TestHarness };
+function expectMsgToHaveSingleQuery(msg) {
+  return expect(msg)
+    .to.be.an.instanceOf(Msg)
+    .and.to.have.property('query')
+    .that.is.an('array')
+    .with.lengthOf(1)
+    .that.has.property(0)
+    .that.is.an('object');
+}
+
+module.exports = { parseOpMsg, TestHarness, expectMsgToHaveSingleQuery };

--- a/test/tests/unit/wireprotocol/3_6/utils.js
+++ b/test/tests/unit/wireprotocol/3_6/utils.js
@@ -1,18 +1,34 @@
 'use strict';
 
-const shared = require('../../../../../lib/wireprotocol/shared');
-const parseHeader = shared.parseHeader;
 const chai = require('chai');
 const sinon = require('sinon');
+const BSON = require('bson');
+const Pool = require('../../../../../lib/connection/pool');
+const shared = require('../../../../../lib/wireprotocol/shared');
+const errors = require('../../../../../lib/error');
+const parseHeader = shared.parseHeader;
 
 chai.use(require('sinon-chai'));
 
-function makeSinonSandbox() {
-  const sandbox = sinon.createSandbox();
+class TestHarness {
+  constructor() {
+    this.sinon = sinon.createSandbox();
+    this.MongoError = errors.MongoError;
+    this.MongoNetworkError = errors.MongoNetworkError;
+    beforeEach(() => this.beforeEach());
+    afterEach(() => this.afterEach());
+  }
 
-  afterEach(() => sandbox.restore());
+  beforeEach() {
+    this.bson = sinon.createStubInstance(BSON);
+    this.pool = sinon.createStubInstance(Pool);
+    this.pool.isConnected.returns(true);
+    this.callback = sinon.stub();
+  }
 
-  return sandbox;
+  afterEach() {
+    this.sinon.restore();
+  }
 }
 
 const OFFSETS = {
@@ -69,4 +85,4 @@ function parseOpMsg(data) {
   return { header, flags, segments, fullSize: data.length, rawData: data };
 }
 
-module.exports = { parseOpMsg, makeSinonSandbox };
+module.exports = { parseOpMsg, TestHarness };

--- a/test/tests/unit/wireprotocol/3_6/utils.js
+++ b/test/tests/unit/wireprotocol/3_6/utils.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const shared = require('../../../../../lib/wireprotocol/shared');
+const parseHeader = shared.parseHeader;
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.use(require('sinon-chai'));
+
+function makeSinonSandbox() {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => sandbox.restore());
+
+  return sandbox;
+}
+
+const OFFSETS = {
+  FLAGS_FROM_START: 16,
+  SEGMENTS_FROM_START: 20,
+  PAYLOAD_FROM_SEGMENT: 1,
+  ARGUMENT_FROM_PAYLOAD: 4
+};
+
+function parseSegmentAt(data, start) {
+  let index = start;
+  const payloadType = data.readUInt8(index);
+  index += OFFSETS.PAYLOAD_FROM_SEGMENT;
+  const payloadSize = data.readUInt32LE(index);
+
+  const documents = [];
+  let argument = undefined;
+
+  if (payloadType === 0) {
+    documents.push(data.slice(index, index + payloadSize));
+  } else if (payloadType === 1) {
+    const end = index + payloadSize;
+    index += OFFSETS.ARGUMENT_FROM_PAYLOAD;
+    argument = data.toString('utf8', index, data.indexOf(0, index));
+    index += argument.length + 1;
+
+    while (index < end) {
+      const docSize = data.readUInt32LE(index);
+      documents.push(data.slice(index, index + docSize));
+      index += docSize;
+    }
+  }
+
+  return { payloadType, payloadSize, argument, documents };
+}
+
+function parseOpMsg(data) {
+  if (!Buffer.isBuffer(data) && Buffer.isBuffer(data[0])) {
+    data = Buffer.concat(data);
+  }
+
+  const header = parseHeader(data);
+  const flags = data.readInt32LE(OFFSETS.FLAGS_FROM_START);
+  const segments = [];
+
+  let index = OFFSETS.SEGMENTS_FROM_START;
+  const totalDataLength = data.length;
+  while (index < totalDataLength) {
+    const segment = parseSegmentAt(data, index);
+    segments.push(segment);
+    index += segment.payloadSize + 1;
+  }
+
+  return { header, flags, segments, fullSize: data.length, rawData: data };
+}
+
+module.exports = { parseOpMsg, makeSinonSandbox };

--- a/test/tests/unit/wireprotocol/3_6/write_tests.js
+++ b/test/tests/unit/wireprotocol/3_6/write_tests.js
@@ -79,6 +79,28 @@ const MongoError = require('../../../../../lib/error').MongoError;
         });
     });
 
+    it('should properly set the moreToCome flag for w: 0', function() {
+      const ops = [
+        { temba: 'his arms wide' },
+        { temba: 'at rest' },
+        { shaka: 'when the walls fell' }
+      ];
+
+      const options = {
+        writeConcern: {
+          w: 0
+        }
+      };
+
+      executeWrite(pool, bson, TYPE, OPSFIELD, 'darmok.jalad', ops, options, callback);
+
+      expect(pool.write).to.have.been.calledOnce;
+
+      const msg = pool.write.firstCall.args[0];
+
+      expect(msg).to.have.property('moreToCome', true);
+    });
+
     // TODO: do we need to actually test this?
     describe.skip('option tests', function() {
       it('ordered');

--- a/test/tests/unit/wireprotocol/3_6/write_tests.js
+++ b/test/tests/unit/wireprotocol/3_6/write_tests.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const expect = require('chai').expect;
+const makeSinonSandbox = require('./utils').makeSinonSandbox;
+const executeWrite = require('../../../../../lib/wireprotocol/3_6_support/execute_write');
+const Pool = require('../../../../../lib/connection/pool');
+const BSON = require('bson');
+const MongoError = require('../../../../../lib/error').MongoError;
+
+[
+  { type: 'insert', opsField: 'documents' },
+  { type: 'update', opsField: 'updates' },
+  { type: 'delete', opsField: 'deletes' }
+].forEach(opMeta => {
+  const TYPE = opMeta.type;
+  const OPSFIELD = opMeta.opsField;
+
+  describe(`Wire Protocol 3.6 ${TYPE}`, function() {
+    const sinon = makeSinonSandbox();
+    let bson, pool, callback;
+
+    beforeEach(() => {
+      bson = sinon.createStubInstance(BSON);
+      pool = sinon.createStubInstance(Pool);
+      callback = sinon.stub();
+    });
+
+    it('should throw if no documents are provided', function() {
+      const badValues = [
+        0,
+        1,
+        -1,
+        'darmok',
+        'jalad',
+        { delete: 'collection' },
+        null,
+        undefined,
+        []
+      ];
+      badValues.forEach(badValue => {
+        const failingFunction = () =>
+          executeWrite(bson, pool, TYPE, OPSFIELD, 'darmok.jalad', badValue, {}, callback);
+        const stringOfBadValue = JSON.stringify(badValue);
+        expect(
+          failingFunction,
+          `Expected executeWrite to fail when ops === ${stringOfBadValue}, but it succeeded`
+        )
+          .to.throw(MongoError)
+          .with.property('message')
+          .that.equals('write operation must contain at least one document');
+      });
+    });
+
+    it(`should properly split namespace and operations across $db, ${TYPE} and ${OPSFIELD}`, function() {
+      const ops = [
+        { temba: 'his arms wide' },
+        { temba: 'at rest' },
+        { shaka: 'when the walls fell' }
+      ];
+
+      executeWrite(pool, bson, TYPE, OPSFIELD, 'darmok.jalad', ops, callback);
+
+      expect(pool.write).to.have.been.calledOnce.and.to.have.been.calledWith(
+        sinon.match({ query: sinon.match.any }),
+        sinon.match.any,
+        callback
+      );
+
+      const msg = pool.write.firstCall.args[0];
+
+      expect(msg)
+        .to.have.property('query')
+        .with.lengthOf(1)
+        .that.has.property(0)
+        .that.includes({
+          $db: 'darmok',
+          [TYPE]: 'jalad',
+          [OPSFIELD]: ops
+        });
+    });
+
+    // TODO: do we need to actually test this?
+    describe.skip('option tests', function() {
+      it('ordered');
+      it('writeConcern');
+      it('collation');
+      it('bypassDocumentValidation');
+      it('txnNumber');
+      it('session');
+      it('chckKeys');
+      it('serializeFunctions');
+      it('ignoreUndefined');
+    });
+  });
+});


### PR DESCRIPTION
Adding implementation of OP_MSG and 3.6 wire protocol.
This is currrently untested and not hooked in to the overall core
driver.

Things that still need to happen:

- [x] Implement Read Preferences
- [x] Implement writeConcern 0
- [ ] Unit Tests
    - [x] OP_MSG serialization tests
    - [x] write tests
    - [x] kill cursor tests
    - [ ] find tests
    - [ ] command tests
    - [ ] get more tests
- [ ] Functional Tests: verify that these things work against the server
- [ ] [Optional] Implement checksum