### PR TITLE
Help 5834:  fix(sessions): actually allow ending of sessions

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -141,6 +141,13 @@ class ServerSessionPool {
     this.sessions = [];
   }
 
+  endAllPooledSessions() {
+    if (this.sessions.length) {
+      this.topology.endSessions(this.sessions.map(session => session.id));
+      this.sessions = [];
+    }
+  }
+
   /**
    * @returns {ServerSession}
    */

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -378,11 +378,6 @@ function resolveClusterTime(topology, $clusterTime) {
 //       to share code.
 const SessionMixins = {
   endSessions: function(sessions, callback) {
-    if (this.isConnected()) {
-      if (typeof callback === 'function') callback();
-      return;
-    }
-
     if (!Array.isArray(sessions)) {
       sessions = [sessions];
     }
@@ -395,7 +390,7 @@ const SessionMixins = {
     //   Is it enough to use: ReadPreference.primaryPreferred ?
     this.command(
       'admin.$cmd',
-      { endSessions: sessions.map(s => s.id) },
+      { endSessions: sessions },
       { readPreference: ReadPreference.primaryPreferred },
       () => {
         // intentionally ignored, per spec


### PR DESCRIPTION
Currently, endSessions filters out any calls that happen while
the topology is connected. However, it is impossible to send
an endSessions command if you are not connected. This fix allows
sessions to be ended while the topology is connected.

Also adds a helper method that `native` can call to easily end all pooled sessions.

WIP b/c this currently breaks APM tests in native.