### PR TITLE
updated package.json peerOptionalDependencies to support bson-ext 2.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "peerOptionalDependencies": {
     "kerberos": "^0.0.23",
     "snappy": "^6.0.1",
-    "bson-ext": "1.0.5"
+    "bson-ext": "^2.0.0"
   },
   "author": "Christian Kvalheim",
   "license": "Apache-2.0",


### PR DESCRIPTION
This pr fixes an issue where bson-ext uses an outdated version and as a result the current mongodb [documents](http://mongodb.github.io/node-mongodb-native/3.0/installation-guide/installation-guide/) are incorrect, running `npm install bson-ext --save` will install a package that won't be detected by the driver since it's outside the expected version number, ideally until this is merged the driver documentation should be updated as well, this has a heavy impact on node.js servers as they will be running the JS version of Bson possibly in production without knowing it.