### PR TITLE
WIP: Initial pass at prefetching the next 'getmore' call

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -576,6 +576,25 @@ var clearCursorDocuments = function(self) {
   self.cursorState.cursorIndex = 0;
 };
 
+var dequeueNextBatch = function(self) {
+  var nextBatch = self.cursorState.nextBatches.shift();
+  self.cursorState.documents = nextBatch.documents;
+};
+
+var prefetch = function(self) {
+  // If prefetching has been enabled, request the next batch now
+  if (!self.options.prefetchBatches) return;
+
+  getMore(self, function(err) {
+    if (err) {
+      self.cursorState.prefetchingError = err;
+      if (self.logger.isInfo()) {
+        self.logger.info('An error occurred prefetching next batch.', err);
+      }
+    }
+  });
+};
+
 var getMore = function(self, callback) {
   // If the next batch has already been requested, exit early
   // so that we don't request yet another batch
@@ -586,16 +605,14 @@ var getMore = function(self, callback) {
   self._getmore(function(err, doc, connection) {
     self.cursorState.isGettingMore = false;
 
+    if (err) return handleCallback(callback, err);
+
     // If we've received the next batch but processing of the current
     // batch hasn't completed yet, exit early.
     if (self.cursorState.documents.length !== self.cursorState.cursorIndex) return;
 
     // Remove the next pending batch and set the current cursorId and documents array
-    var nextBatch = self.cursorState.nextBatches.shift();
-    self.cursorState.documents = nextBatch.documents;
-    self.cursorState.cursorId = nextBatch.cursorId;
-
-    if (err) return handleCallback(callback, err);
+    dequeueNextBatch(self);
 
     if (self.cursorState.cursorId && self.cursorState.cursorId.isZero() && self._endSession) {
       self._endSession();
@@ -641,6 +658,11 @@ var nextFunction = function(self, callback) {
   // We have notified about it
   if (self.cursorState.notified) {
     return callback(new Error('cursor is exhausted'));
+  }
+
+  // If there was an error prefetching the last batch, return the error now
+  if (self.cursorState.prefetchingError) {
+    return callback(self.cursorState.prefetchingError);
   }
 
   // Cursor is killed return null
@@ -750,6 +772,8 @@ var nextFunction = function(self, callback) {
         return setCursorNotified(self, callback);
       }
 
+      prefetch(self);
+
       nextFunction(self, callback);
     });
   } else if (
@@ -783,14 +807,9 @@ var nextFunction = function(self, callback) {
     }
 
     // The next batch is already available, so use it
-    var nextBatch = self.cursorState.nextBatches.shift();
-    self.cursorState.documents = nextBatch.documents;
-    self.cursorState.cursorId = nextBatch.cursorId;
+    dequeueNextBatch(self);
 
-    // If prefetching has been enabled, request the next batch now
-    if (self.options.prefetchBatches) {
-      getMore(self, callback);
-    }
+    prefetch(self);
 
     return nextFunction(self, callback);
   } else if (

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -103,7 +103,9 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
     batchSize: options.batchSize || cmd.batchSize || 1000,
     currentLimit: 0,
     // Result field name if not a cursor (contains the array of results)
-    transforms: options.transforms
+    transforms: options.transforms,
+    isGettingMore: false,
+    nextBatches: []
   };
 
   // Add promoteLong to cursor state
@@ -358,7 +360,7 @@ Cursor.prototype._killcursor = function(callback) {
   this.cursorState.dead = true;
   this.cursorState.killed = true;
   // Remove documents
-  this.cursorState.documents = [];
+  clearCursorDocuments(this);
 
   // If no cursor id just return
   if (
@@ -485,9 +487,8 @@ Cursor.prototype.rewind = function() {
     this.cursorState.dead = false;
     this.cursorState.killed = false;
     this.cursorState.notified = false;
-    this.cursorState.documents = [];
     this.cursorState.cursorId = null;
-    this.cursorState.cursorIndex = 0;
+    clearCursorDocuments(this);
   }
 };
 
@@ -562,13 +563,79 @@ var setCursorNotified = function(self, callback) {
 
 var _setCursorNotifiedImpl = function(self, callback) {
   self.cursorState.notified = true;
-  self.cursorState.documents = [];
-  self.cursorState.cursorIndex = 0;
+  clearCursorDocuments(self);
   if (self._endSession) {
     return self._endSession(undefined, () => callback());
   }
   return callback();
 };
+
+var clearCursorDocuments = function(self) {
+  self.cursorState.nextBatches = [];
+  self.cursorState.documents = [];
+  self.cursorState.cursorIndex = 0;
+};
+
+var getMore = function(self, callback) {
+  // If the next batch has already been requested, exit early
+  // so that we don't request yet another batch
+  if (self.cursorState.isGettingMore) return;
+  self.cursorState.isGettingMore = true;
+
+  // Execute the next get more
+  self._getmore(function(err, doc, connection) {
+    self.cursorState.isGettingMore = false;
+
+    // If we've received the next batch but processing of the current
+    // batch hasn't completed yet, exit early.
+    if (self.cursorState.documents.length !== self.cursorState.cursorIndex) return;
+
+    // Remove the next pending batch and set the current cursorId and documents array
+    var nextBatch = self.cursorState.nextBatches.shift();
+    self.cursorState.documents = nextBatch.documents;
+    self.cursorState.cursorId = nextBatch.cursorId;
+
+    if (err) return handleCallback(callback, err);
+
+    if (self.cursorState.cursorId && self.cursorState.cursorId.isZero() && self._endSession) {
+      self._endSession();
+    }
+
+    // Save the returned connection to ensure all getMore's fire over the same connection
+    self.connection = connection;
+
+    // Tailable cursor getMore result, notify owner about it
+    // No attempt is made here to retry, this is left to the user of the
+    // core module to handle to keep core simple
+    if (
+      self.cursorState.documents.length === 0 &&
+      self.cmd.tailable &&
+      Long.ZERO.equals(self.cursorState.cursorId)
+    ) {
+      // No more documents in the tailed cursor
+      return handleCallback(
+        callback,
+        new MongoError({
+          message: 'No more documents in tailed cursor',
+          tailable: self.cmd.tailable,
+          awaitData: self.cmd.awaitData
+        })
+      );
+    } else if (
+      self.cursorState.documents.length === 0 &&
+      self.cmd.tailable &&
+      !Long.ZERO.equals(self.cursorState.cursorId)
+    ) {
+      return nextFunction(self, callback);
+    }
+
+    if (self.cursorState.limit > 0 && self.cursorState.currentLimit >= self.cursorState.limit) {
+      return setCursorDeadAndNotified(self, callback);
+    }
+
+    nextFunction(self, callback);
+  });
+}
 
 var nextFunction = function(self, callback) {
   // We have notified about it
@@ -698,8 +765,7 @@ var nextFunction = function(self, callback) {
     !Long.ZERO.equals(self.cursorState.cursorId)
   ) {
     // Ensure an empty cursor state
-    self.cursorState.documents = [];
-    self.cursorState.cursorIndex = 0;
+    clearCursorDocuments(self);
 
     // Check if topology is destroyed
     if (self.topology.isDestroyed())
@@ -711,48 +777,22 @@ var nextFunction = function(self, callback) {
     // execute a getmore on this connection
     if (isConnectionDead(self, callback)) return;
 
-    // Execute the next get more
-    self._getmore(function(err, doc, connection) {
-      if (err) return handleCallback(callback, err);
+    // If the next batch isn't already available, try requesting it
+    if (self.cursorState.nextBatches.length === 0) {
+      return getMore(self, callback);
+    }
 
-      if (self.cursorState.cursorId && self.cursorState.cursorId.isZero() && self._endSession) {
-        self._endSession();
-      }
+    // The next batch is already available, so use it
+    var nextBatch = self.cursorState.nextBatches.shift();
+    self.cursorState.documents = nextBatch.documents;
+    self.cursorState.cursorId = nextBatch.cursorId;
 
-      // Save the returned connection to ensure all getMore's fire over the same connection
-      self.connection = connection;
+    // If prefetching has been enabled, request the next batch now
+    if (self.options.prefetchBatches) {
+      getMore(self, callback);
+    }
 
-      // Tailable cursor getMore result, notify owner about it
-      // No attempt is made here to retry, this is left to the user of the
-      // core module to handle to keep core simple
-      if (
-        self.cursorState.documents.length === 0 &&
-        self.cmd.tailable &&
-        Long.ZERO.equals(self.cursorState.cursorId)
-      ) {
-        // No more documents in the tailed cursor
-        return handleCallback(
-          callback,
-          new MongoError({
-            message: 'No more documents in tailed cursor',
-            tailable: self.cmd.tailable,
-            awaitData: self.cmd.awaitData
-          })
-        );
-      } else if (
-        self.cursorState.documents.length === 0 &&
-        self.cmd.tailable &&
-        !Long.ZERO.equals(self.cursorState.cursorId)
-      ) {
-        return nextFunction(self, callback);
-      }
-
-      if (self.cursorState.limit > 0 && self.cursorState.currentLimit >= self.cursorState.limit) {
-        return setCursorDeadAndNotified(self, callback);
-      }
-
-      nextFunction(self, callback);
-    });
+    return nextFunction(self, callback);
   } else if (
     self.cursorState.documents.length === self.cursorState.cursorIndex &&
     self.cmd.tailable &&

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -635,7 +635,7 @@ var getMore = function(self, callback) {
 
     nextFunction(self, callback);
   });
-}
+};
 
 var nextFunction = function(self, callback) {
   // We have notified about it

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -140,8 +140,10 @@ WireProtocol.prototype.getMore = function(
     var cursorId = typeof r.cursorId === 'number' ? Long.fromNumber(r.cursorId) : r.cursorId;
 
     // Set all the values
-    cursorState.documents = r.documents;
-    cursorState.cursorId = cursorId;
+    cursorState.nextBatches.push({
+      documents: r.documents,
+      cursorId: cursorId
+    });
 
     // Return
     callback(null, null, r.connection);

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -140,10 +140,8 @@ WireProtocol.prototype.getMore = function(
     var cursorId = typeof r.cursorId === 'number' ? Long.fromNumber(r.cursorId) : r.cursorId;
 
     // Set all the values
-    cursorState.nextBatches.push({
-      documents: r.documents,
-      cursorId: cursorId
-    });
+    cursorState.cursorId = cursorId;
+    cursorState.nextBatches.push({ documents: r.documents });
 
     // Return
     callback(null, null, r.connection);

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -221,10 +221,8 @@ WireProtocol.prototype.getMore = function(
 
     // Raw, return all the extracted documents
     if (raw) {
-      cursorState.nextBatches.push({
-        documents: r.documents,
-        cursorId: r.cursorId
-      });
+      cursorState.cursorId = r.cursorId;
+      cursorState.nextBatches.push({ documents: r.documents });
 
       return callback(null, r.documents);
     }
@@ -241,10 +239,8 @@ WireProtocol.prototype.getMore = function(
         : r.documents[0].cursor.id;
 
     // Set all the values
-    cursorState.nextBatches.push({
-      documents: r.documents[0].cursor.nextBatch,
-      cursorId: cursorId
-    });
+    cursorState.cursorId = cursorId;
+    cursorState.nextBatches.push({ documents: r.documents[0].cursor.nextBatch });
 
     // Return the result
     callback(null, r.documents[0], r.connection);

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -221,8 +221,11 @@ WireProtocol.prototype.getMore = function(
 
     // Raw, return all the extracted documents
     if (raw) {
-      cursorState.documents = r.documents;
-      cursorState.cursorId = r.cursorId;
+      cursorState.nextBatches.push({
+        documents: r.documents,
+        cursorId: r.cursorId
+      });
+
       return callback(null, r.documents);
     }
 
@@ -238,8 +241,10 @@ WireProtocol.prototype.getMore = function(
         : r.documents[0].cursor.id;
 
     // Set all the values
-    cursorState.documents = r.documents[0].cursor.nextBatch;
-    cursorState.cursorId = cursorId;
+    cursorState.nextBatches.push({
+      documents: r.documents[0].cursor.nextBatch,
+      cursorId: cursorId
+    });
 
     // Return the result
     callback(null, r.documents[0], r.connection);


### PR DESCRIPTION
This PR is a work-in-progress and is not intended to be merged in at this point. It addresses this feature request: https://jira.mongodb.org/browse/NODE-1375

The idea behind the feature is to not wait for the processing of the current batch of documents to be completed _before_ making the next `getmore` call. Instead, the idea is to better pipeline the process by making the next `getmore` call _in parallel_ with the processing of the current batch.

This is critical for our application as we have found that we spend a significant amount of time waiting on the next batch of results to process.

This PR is only intended to:
1. Show a possible implementation
2. See if there is any interest from the maintainers of mongodb-core in such a PR
3. Determine if this is a reasonable approach to the proposed feature
4. See if there are any implementation details that I'm not aware of that would need to be addressed for this to work

Thanks in advance for your feedback :)