### PR TITLE
fix(auth): pass auth result to callback

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -824,7 +824,7 @@ Pool.prototype.auth = function(mechanism) {
 
     // Authenticate the connections
     for (var i = 0; i < connections.length; i++) {
-      authenticate(self, args, connections[i], function(err) {
+      authenticate(self, args, connections[i], function(err, result) {
         connectionsCount = connectionsCount - 1;
 
         // Store the error
@@ -850,9 +850,9 @@ Pool.prototype.auth = function(mechanism) {
               );
             }
 
-            return cb(error);
+            return cb(error, result);
           }
-          cb(null);
+          cb(null, result);
         }
       });
     }
@@ -869,12 +869,12 @@ Pool.prototype.auth = function(mechanism) {
   // Wait for loggout to finish
   waitForLogout(self, function() {
     // Authenticate all live connections
-    authenticateLiveConnections(self, args, function(err) {
+    authenticateLiveConnections(self, args, function(err, result) {
       // Credentials correctly stored in auth provider if successful
       // Any new connections will now reauthenticate correctly
       self.authenticating = false;
       // Return after authentication connections
-      callback(err);
+      callback(err, result);
     });
   });
 };


### PR DESCRIPTION
We were only passing the error, and not the auth result,
to the auth callback in the pool