### PR TITLE
feat(transactions): add initial support for multi-stage transactions on replicasets

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -244,7 +244,7 @@ function endTransaction(clientSession, commandName, callback) {
   if (clientSession.transactionOptions.writeConcern) {
     Object.assign(command, { writeConcern: clientSession.transactionOptions.writeConcern });
   } else if (clientSession.clientOptions.w) {
-    Object.assign(command, { writeConcern: { w: parseInt(clientSession.clientOptions.w, 10) } });
+    Object.assign(command, { writeConcern: { w: clientSession.clientOptions.w } });
   }
 
   function commandHandler(e, r) {

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -224,6 +224,13 @@ function endTransaction(clientSession, commandName, callback) {
 
   if (clientSession.serverSession.stmtId === 0) {
     // The server transaction was never started.
+
+    // reset internal transaction state
+    clientSession.transactionOptions = null;
+    if (clientSession.autoStartTransaction) {
+      clientSession.startTransaction();
+    }
+
     callback(null, null);
     return;
   }
@@ -243,7 +250,6 @@ function endTransaction(clientSession, commandName, callback) {
     (err, reply) => {
       // reset internal transaction state
       clientSession.transactionOptions = null;
-
       if (clientSession.autoStartTransaction) {
         clientSession.startTransaction();
       }

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -249,6 +249,10 @@ function endTransaction(clientSession, commandName, callback) {
     callback(e, r);
   }
 
+  function transactionError(err) {
+    return commandName === 'commitTransaction' ? err : null;
+  }
+
   // send the command
   clientSession.topology.command(
     'admin.$cmd',
@@ -260,11 +264,11 @@ function endTransaction(clientSession, commandName, callback) {
           'admin.$cmd',
           command,
           { session: clientSession },
-          (_err, _reply) => commandHandler(null, _reply)
+          (_err, _reply) => commandHandler(transactionError(_err), _reply)
         );
       }
 
-      commandHandler(null, reply);
+      commandHandler(transactionError(err), reply);
     }
   );
 }

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -6,6 +6,7 @@ const BSON = retrieveBSON();
 const Binary = BSON.Binary;
 const uuidV4 = require('./utils').uuidV4;
 const MongoError = require('./error').MongoError;
+const MongoNetworkError = require('./error').MongoNetworkError;
 
 function assertAlive(session, callback) {
   if (session.serverSession == null) {
@@ -206,9 +207,33 @@ class ClientSession extends EventEmitter {
   }
 }
 
+// see: https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst#terms
+const RETRYABLE_ERROR_CODES = new Set([
+  6, // HostUnreachable
+  7, // HostNotFound
+  64, // WriteConcernFailed
+  89, // NetworkTimeout
+  91, // ShutdownInProgress
+  189, // PrimarySteppedDown
+  9001, // SocketException
+  11600, // InterruptedAtShutdown
+  11602, // InterruptedDueToReplStateChange
+  10107, // NotMaster
+  13435, // NotMasterNoSlaveOk
+  13436 // NotMasterOrSecondary
+]);
+
 function isRetryableError(error) {
-  if (error.codeName === 'NoSuchTransaction') return false;
-  return true;
+  if (
+    RETRYABLE_ERROR_CODES.has(error.code) ||
+    error instanceof MongoNetworkError ||
+    error.message.match(/not master/) ||
+    error.message.match(/node is recovering/)
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function resetTransactionState(clientSession) {

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -1,23 +1,22 @@
 'use strict';
 
-const inherits = require('util').inherits,
-  f = require('util').format,
-  EventEmitter = require('events').EventEmitter,
-  BasicCursor = require('../cursor'),
-  Logger = require('../connection/logger'),
-  retrieveBSON = require('../connection/utils').retrieveBSON,
-  MongoError = require('../error').MongoError,
-  errors = require('../error'),
-  Server = require('./server'),
-  clone = require('./shared').clone,
-  diff = require('./shared').diff,
-  cloneOptions = require('./shared').cloneOptions,
-  createClientInfo = require('./shared').createClientInfo,
-  SessionMixins = require('./shared').SessionMixins,
-  isRetryableWritesSupported = require('./shared').isRetryableWritesSupported,
-  getNextTransactionNumber = require('./shared').getNextTransactionNumber,
-  relayEvents = require('./shared').relayEvents;
-
+const inherits = require('util').inherits;
+const f = require('util').format;
+const EventEmitter = require('events').EventEmitter;
+const BasicCursor = require('../cursor');
+const Logger = require('../connection/logger');
+const retrieveBSON = require('../connection/utils').retrieveBSON;
+const MongoError = require('../error').MongoError;
+const errors = require('../error');
+const Server = require('./server');
+const clone = require('./shared').clone;
+const diff = require('./shared').diff;
+const cloneOptions = require('./shared').cloneOptions;
+const createClientInfo = require('./shared').createClientInfo;
+const SessionMixins = require('./shared').SessionMixins;
+const isRetryableWritesSupported = require('./shared').isRetryableWritesSupported;
+const incrementTransactionNumber = require('./shared').incrementTransactionNumber;
+const relayEvents = require('./shared').relayEvents;
 const BSON = retrieveBSON();
 
 /**
@@ -909,7 +908,7 @@ var executeWriteOperation = function(self, op, ns, ops, options, callback) {
   }
 
   // increment and assign txnNumber
-  options.txnNumber = getNextTransactionNumber(options.session);
+  incrementTransactionNumber(options.session);
 
   server[op](ns, ops, options, (err, result) => {
     if (!err) return callback(null, result);

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1,24 +1,24 @@
 'use strict';
 
-var inherits = require('util').inherits,
-  f = require('util').format,
-  EventEmitter = require('events').EventEmitter,
-  ReadPreference = require('./read_preference'),
-  BasicCursor = require('../cursor'),
-  retrieveBSON = require('../connection/utils').retrieveBSON,
-  Logger = require('../connection/logger'),
-  MongoError = require('../error').MongoError,
-  errors = require('../error'),
-  Server = require('./server'),
-  ReplSetState = require('./replset_state'),
-  clone = require('./shared').clone,
-  Timeout = require('./shared').Timeout,
-  Interval = require('./shared').Interval,
-  createClientInfo = require('./shared').createClientInfo,
-  SessionMixins = require('./shared').SessionMixins,
-  isRetryableWritesSupported = require('./shared').isRetryableWritesSupported,
-  getNextTransactionNumber = require('./shared').getNextTransactionNumber,
-  relayEvents = require('./shared').relayEvents;
+const inherits = require('util').inherits;
+const f = require('util').format;
+const EventEmitter = require('events').EventEmitter;
+const ReadPreference = require('./read_preference');
+const BasicCursor = require('../cursor');
+const retrieveBSON = require('../connection/utils').retrieveBSON;
+const Logger = require('../connection/logger');
+const MongoError = require('../error').MongoError;
+const errors = require('../error');
+const Server = require('./server');
+const ReplSetState = require('./replset_state');
+const clone = require('./shared').clone;
+const Timeout = require('./shared').Timeout;
+const Interval = require('./shared').Interval;
+const createClientInfo = require('./shared').createClientInfo;
+const SessionMixins = require('./shared').SessionMixins;
+const isRetryableWritesSupported = require('./shared').isRetryableWritesSupported;
+const incrementTransactionNumber = require('./shared').incrementTransactionNumber;
+const relayEvents = require('./shared').relayEvents;
 
 var MongoCR = require('../auth/mongocr'),
   X509 = require('../auth/x509'),
@@ -1230,7 +1230,7 @@ function executeWriteOperation(args, options, callback) {
 
   // increment and assign txnNumber
   if (willRetryWrite) {
-    options.txnNumber = getNextTransactionNumber(options.session);
+    incrementTransactionNumber(options.session);
   }
 
   return self.s.replicaSetState.primary[op](ns, ops, options, handler);

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -17,8 +17,6 @@ const Interval = require('./shared').Interval;
 const createClientInfo = require('./shared').createClientInfo;
 const SessionMixins = require('./shared').SessionMixins;
 const isRetryableWritesSupported = require('./shared').isRetryableWritesSupported;
-const incrementTransactionNumber = require('./shared').incrementTransactionNumber;
-const incrementStatementId = require('./shared').incrementStatementId;
 const relayEvents = require('./shared').relayEvents;
 
 var MongoCR = require('../auth/mongocr'),
@@ -1244,7 +1242,7 @@ function executeWriteOperation(args, options, callback) {
 
   // increment and assign txnNumber
   if (willRetryWrite) {
-    incrementTransactionNumber(options.session);
+    options.session.incrementTransactionNumber();
   }
 
   // optionally autostart transaction if requested
@@ -1254,7 +1252,7 @@ function executeWriteOperation(args, options, callback) {
 
   // We need to increment the statement id if we're in a transaction
   if (options.session && options.session.inTransaction()) {
-    incrementStatementId(options.session, ops.length);
+    options.session.incrementStatementId(ops.length);
   }
 }
 

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1196,7 +1196,11 @@ function executeWriteOperation(args, options, callback) {
   }
 
   const willRetryWrite =
-    !args.retrying && options.retryWrites && options.session && isRetryableWritesSupported(self);
+    !args.retrying &&
+    options.retryWrites &&
+    options.session &&
+    isRetryableWritesSupported(self) &&
+    !options.session.inTransaction();
 
   if (!self.s.replicaSetState.hasPrimary()) {
     if (self.s.disconnectHandler) {

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1321,6 +1321,14 @@ ReplSet.prototype.command = function(ns, cmd, options, callback) {
   // Establish readPreference
   var readPreference = options.readPreference ? options.readPreference : ReadPreference.primary;
 
+  if (
+    options.session &&
+    options.session.inTransaction() &&
+    !readPreference.equals(ReadPreference.primary)
+  ) {
+    return callback(new MongoError('Read preference in a transaction must be primary'));
+  }
+
   // If the readPreference is primary and we have no primary, store it
   if (
     readPreference.preference === 'primary' &&

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1361,11 +1361,6 @@ ReplSet.prototype.command = function(ns, cmd, options, callback) {
 
   // Execute the command
   server.command(ns, cmd, options, callback);
-
-  // We need to increment the statement id if we're in a transaction
-  if (options.session && options.session.inTransaction()) {
-    incrementStatementId(options.session);
-  }
 };
 
 /**

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -425,9 +425,8 @@ const isRetryableWritesSupported = function(topology) {
  *
  * @param {ClientSession} session
  */
-const getNextTransactionNumber = function(session) {
+const incrementTransactionNumber = function(session) {
   session.serverSession.txnNumber++;
-  return BSON.Long.fromNumber(session.serverSession.txnNumber);
 };
 
 /**
@@ -454,5 +453,5 @@ module.exports.diff = diff;
 module.exports.Interval = Interval;
 module.exports.Timeout = Timeout;
 module.exports.isRetryableWritesSupported = isRetryableWritesSupported;
-module.exports.getNextTransactionNumber = getNextTransactionNumber;
+module.exports.incrementTransactionNumber = incrementTransactionNumber;
 module.exports.relayEvents = relayEvents;

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -418,26 +418,6 @@ const isRetryableWritesSupported = function(topology) {
 };
 
 /**
- * Increment the transaction number on the ServerSession contained by the provided ClientSession
- *
- * @param {ClientSession} session
- */
-function incrementTransactionNumber(session) {
-  session.serverSession.txnNumber++;
-}
-
-/**
- * Increment the statement id on the ServerSession contained by the provided ClientSession
- *
- * @param {ClientSession} session the client sessions
- * @param {Number} [operationCount] the number of operations performed
- */
-function incrementStatementId(session, operationCount) {
-  operationCount = operationCount || 1;
-  session.serverSession.stmtId += operationCount;
-}
-
-/**
  * Relays events for a given listener and emitter
  *
  * @param {EventEmitter} listener the EventEmitter to listen to the events for
@@ -461,6 +441,4 @@ module.exports.diff = diff;
 module.exports.Interval = Interval;
 module.exports.Timeout = Timeout;
 module.exports.isRetryableWritesSupported = isRetryableWritesSupported;
-module.exports.incrementTransactionNumber = incrementTransactionNumber;
-module.exports.incrementStatementId = incrementStatementId;
 module.exports.relayEvents = relayEvents;

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const os = require('os'),
-  f = require('util').format,
-  ReadPreference = require('./read_preference'),
-  retrieveBSON = require('../connection/utils').retrieveBSON;
-
-const BSON = retrieveBSON();
+const os = require('os');
+const f = require('util').format;
+const ReadPreference = require('./read_preference');
 
 /**
  * Emit event if it exists
@@ -427,7 +424,7 @@ const isRetryableWritesSupported = function(topology) {
  */
 function incrementTransactionNumber(session) {
   session.serverSession.txnNumber++;
-};
+}
 
 /**
  * Increment the statement id on the ServerSession contained by the provided ClientSession
@@ -438,7 +435,7 @@ function incrementTransactionNumber(session) {
 function incrementStatementId(session, operationCount) {
   operationCount = operationCount || 1;
   session.serverSession.stmtId += operationCount;
-};
+}
 
 /**
  * Relays events for a given listener and emitter

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -425,8 +425,19 @@ const isRetryableWritesSupported = function(topology) {
  *
  * @param {ClientSession} session
  */
-const incrementTransactionNumber = function(session) {
+function incrementTransactionNumber(session) {
   session.serverSession.txnNumber++;
+};
+
+/**
+ * Increment the statement id on the ServerSession contained by the provided ClientSession
+ *
+ * @param {ClientSession} session the client sessions
+ * @param {Number} [operationCount] the number of operations performed
+ */
+function incrementStatementId(session, operationCount) {
+  operationCount = operationCount || 1;
+  session.serverSession.stmtId += operationCount;
 };
 
 /**
@@ -454,4 +465,5 @@ module.exports.Interval = Interval;
 module.exports.Timeout = Timeout;
 module.exports.isRetryableWritesSupported = isRetryableWritesSupported;
 module.exports.incrementTransactionNumber = incrementTransactionNumber;
+module.exports.incrementStatementId = incrementStatementId;
 module.exports.relayEvents = relayEvents;

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -329,6 +329,11 @@ WireProtocol.prototype.getMore = function(
     queryOptions.session = cursorState.session;
   }
 
+  // We need to increment the statement id if we're in a transaction
+  if (options.session && options.session.inTransaction()) {
+    incrementStatementId(options.session);
+  }
+
   // Write out the getMore command
   connection.write(query, queryOptions, queryCallback);
 };

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -37,18 +37,6 @@ function decorateWithTransactionsData(command, session) {
     return;
   }
 
-  if (session.transactionOptions.writeConcern) {
-    if (command.writeConcern) {
-      command.writeConcern = Object.assign(
-        {},
-        session.transactionOptions.writeConcern,
-        command.writeConcern
-      );
-    } else {
-      command.writeConcern = Object.assign({}, session.transactionOptions.writeConcern);
-    }
-  }
-
   command.stmtId = serverSession.stmtId;
   command.autocommit = false;
 

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -29,6 +29,7 @@ function decorateWithTransactionsData(command, session) {
   if (session.transactionOptions.writeConcern) {
     if (command.writeConcern) {
       command.writeConcern = Object.assign(
+        {},
         session.transactionOptions.writeConcern,
         command.writeConcern
       );

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -7,7 +7,6 @@ const MongoError = require('../error').MongoError;
 const MongoNetworkError = require('../error').MongoNetworkError;
 const getReadPreference = require('./shared').getReadPreference;
 const incrementStatementId = require('../topologies/shared').incrementStatementId;
-const ReadPreference = require('../topologies/read_preference');
 const BSON = retrieveBSON();
 const Long = BSON.Long;
 
@@ -166,9 +165,6 @@ WireProtocol.prototype.killCursor = function(bson, ns, cursorState, pool, callba
     returnFieldSelector: null
   });
 
-  // Set query flags
-  query.slaveOk = true;
-
   // Kill cursor callback
   var killCursorCallback = function(err, result) {
     if (err) {
@@ -254,9 +250,6 @@ WireProtocol.prototype.getMore = function(
     checkKeys: false,
     returnFieldSelector: null
   });
-
-  // Set query flags
-  query.slaveOk = true;
 
   // Query callback
   var queryCallback = function(err, result) {

--- a/lib/wireprotocol/shared.js
+++ b/lib/wireprotocol/shared.js
@@ -31,10 +31,14 @@ var getReadPreference = function(cmd, options) {
   }
 
   if (!(readPreference instanceof ReadPreference)) {
-    throw new MongoError('readPreference must be a ReadPreference instance');
+    throw new MongoError('read preference must be a ReadPreference instance');
   }
 
-  if (options.session && options.session.inTransaction() && !readPreference.equals(ReadPreference.primary)) {
+  if (
+    options.session &&
+    options.session.inTransaction() &&
+    !readPreference.equals(ReadPreference.primary)
+  ) {
     throw new MongoError('read preference in a transaction must be primary');
   }
 

--- a/lib/wireprotocol/shared.js
+++ b/lib/wireprotocol/shared.js
@@ -34,6 +34,10 @@ var getReadPreference = function(cmd, options) {
     throw new MongoError('readPreference must be a ReadPreference instance');
   }
 
+  if (options.session && options.session.inTransaction() && !readPreference.equals(ReadPreference.primary)) {
+    throw new MongoError('read preference in a transaction must be primary');
+  }
+
   return readPreference;
 };
 


### PR DESCRIPTION
These are the changes required for the core driver in order to support transactions in the mongodb node driver. The meat of the changes exist in the `ClientSession` object, as well as a smattering of logical changes related to whether a given session is currently in a transaction. Please try to focus on functional criticisms, I guarantee you if you're having thoughts about overall architecture I have probably had nightmares about them in the past few weeks