### PR TITLE
docs(sessions): add missing default for `causalConsistency`

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -31,7 +31,7 @@ class ClientSession extends EventEmitter {
    * @param {Topology} topology The current client's topology
    * @param {ServerSessionPool} sessionPool The server session pool
    * @param {Object} [options] Optional settings
-   * @param {Boolean} [options.causalConsistency] Whether causal consistency should be enabled on this session
+   * @param {Boolean} [options.causalConsistency=false] Whether causal consistency should be enabled on this session
    * @param {Boolean} [options.autoStartTransaction=false] When enabled this session automatically starts a transaction with the provided defaultTransactionOptions.
    * @param {Object} [options.defaultTransactionOptions] The default TransactionOptions to use for transactions started on this session.
    * @param {Object} [clientOptions] Optional settings provided when creating a client in the porcelain driver


### PR DESCRIPTION
I'm pretty sure that `causalConsistency` is false by default but I might be wrong. Also, see https://github.com/mongodb/node-mongodb-native/pull/1682