### PR TITLE
fix(sessions): never send `endSessions` from a `ClientSession`

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -78,7 +78,6 @@ class ClientSession extends EventEmitter {
    * Ends this session on the server
    *
    * @param {Object} [options] Optional settings
-   * @param {Boolean} [options.skipCommand] Skip sending the actual endSessions command to the server
    * @param {Function} [callback] Optional callback for completion of this operation
    */
   endSession(options, callback) {
@@ -92,11 +91,6 @@ class ClientSession extends EventEmitter {
 
     if (this.serverSession && this.inTransaction()) {
       this.abortTransaction(); // pass in callback?
-    }
-
-    if (!options.skipCommand) {
-      // send the `endSessions` command
-      this.topology.endSessions(this.id);
     }
 
     // mark the session as ended, and emit a signal


### PR DESCRIPTION
Sessions are meant to be cached, and the `endSessions` command is
only meant to be used as a way to signal to the server that cached
sessions will no longer be used (due to the client closing). We
were sending too many `endSessions` commands, now we just send the
one.

NODE-1418