### PR TITLE
fix(pool): ensure that lsid is sent in get requests to mongos

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -1222,7 +1222,11 @@ Pool.prototype.write = function(commands, options, cb) {
     // decorate the commands with session-specific details
     commands.forEach(command => {
       if (command instanceof Query) {
-        Object.assign(command.query, sessionOptions);
+        if (command.query.$query) {
+          Object.assign(command.query.$query, sessionOptions);
+        } else {
+          Object.assign(command.query, sessionOptions);
+        }
       } else {
         Object.assign(command, sessionOptions);
       }


### PR DESCRIPTION
There is a strange case, when topology is mongos and readPreference
is not primary, where we nest our find queries in a "$query" attribute.
This was having the effect of not sending the lsid on find requests,
which caused further errors when getMores attempted to send an lsid.

Fixes NODE-1420