### PR TITLE
Removing double timeout clear

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1022,7 +1022,6 @@ ReplSet.prototype.destroy = function(options) {
   // Clear out all monitoring
   for (var i = 0; i < this.intervalIds.length; i++) {
     this.intervalIds[i].stop();
-    this.intervalIds[i].stop();
   }
 
   // Reset list of intervalIds


### PR DESCRIPTION
This was accidentally introduced during the following refactor:
https://github.com/mongodb-js/mongodb-core/commit/cd44d70f57661ad63c6a65558ffcfa38d1e7d3a2#diff-dc27eebcc66ed957fe1f8d58c5387d0dL856

There isn't any negative side effects, just unnecessary function calls being made.

Obsoletes #310.