### PR TITLE
NODE-1259(continued): add support for monitoring, and improve server selection

### DIFF
--- a/lib/sdam/monitoring.js
+++ b/lib/sdam/monitoring.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const ServerDescription = require('./server_description').ServerDescription;
+const calculateDurationInMs = require('../utils').calculateDurationInMs;
+
 /**
  * Published when server description changes, but does NOT include changes to the RTT.
  *
@@ -88,7 +91,7 @@ class ServerHeartbeatStartedEvent {
 /**
  * Fired when the server monitor’s ismaster succeeds.
  *
- * @param {Number} duration The execution time of the event
+ * @param {Number} duration The execution time of the event in ms
  * @param {Object} reply The command reply
  * @param {Object} connectionId The connection id for the command
  */
@@ -101,14 +104,102 @@ class ServerHeartbeatSucceededEvent {
 /**
  * Fired when the server monitor’s ismaster fails, either with an “ok: 0” or a socket exception.
  *
- * @param {Number} duration The execution time of the event
+ * @param {Number} duration The execution time of the event in ms
  * @param {MongoError|Object} failure The command failure
  * @param {Object} connectionId The connection id for the command
  */
-class ServerHearbeatFailedEvent {
+class ServerHeartbeatFailedEvent {
   constructor(duration, failure, connectionId) {
     Object.assign(this, { duration, failure, connectionId });
   }
+}
+
+/**
+ * Performs a server check as described by the SDAM spec.
+ *
+ * NOTE: This method automatically reschedules itself, so that there is always an active
+ * monitoring process
+ *
+ * @param {Server} server The server to monitor
+ */
+function monitorServer(server) {
+  // executes a single check of a server
+  const checkServer = callback => {
+    let start = process.hrtime();
+
+    // emit a signal indicating we have started the heartbeat
+    server.emit('serverHeartbeatStarted', new ServerHeartbeatStartedEvent(server.name));
+
+    server.command(
+      'admin.$cmd',
+      { ismaster: true },
+      {
+        monitoring: true,
+        socketTimeout: server.s.options.connectionTimeout || 2000
+      },
+      function(err, result) {
+        let duration = calculateDurationInMs(start);
+
+        if (err) {
+          server.emit(
+            'serverHeartbeatFailed',
+            new ServerHeartbeatFailedEvent(duration, err, server.name)
+          );
+
+          return callback(err, null);
+        }
+
+        const isMaster = result.result;
+        server.emit(
+          'serverHeartbeatSucceded',
+          new ServerHeartbeatSucceededEvent(duration, isMaster, server.name)
+        );
+
+        return callback(null, isMaster);
+      }
+    );
+  };
+
+  const successHandler = isMaster => {
+    server.s.monitoring = false;
+
+    // emit an event indicating that our description has changed
+    server.emit('descriptionReceived', new ServerDescription(server.description.address, isMaster));
+
+    // schedule the next monitoring process
+    server.s.monitorId = setTimeout(
+      () => monitorServer(server),
+      server.s.options.heartbeatFrequencyMS
+    );
+  };
+
+  // run the actual monitoring loop
+  server.s.monitoring = true;
+  checkServer((err, isMaster) => {
+    if (err) {
+      // According to the SDAM specification's "Network error during server check" section, if
+      // an ismaster call fails we reset the server's pool. If a server was once connected,
+      // change its type to `Unknown` only after retrying once.
+
+      // TODO: we need to reset the pool here
+
+      return checkServer((err, isMaster) => {
+        if (err) {
+          server.s.monitoring = false;
+
+          // we revert to an `Unknown` by emitting a default description with no isMaster
+          server.emit('descriptionReceived', new ServerDescription(server.description.address));
+
+          // we do not reschedule monitoring in this case
+          return;
+        }
+
+        successHandler(isMaster);
+      });
+    }
+
+    successHandler(isMaster);
+  });
 }
 
 module.exports = {
@@ -120,5 +211,6 @@ module.exports = {
   TopologyClosedEvent,
   ServerHeartbeatStartedEvent,
   ServerHeartbeatSucceededEvent,
-  ServerHearbeatFailedEvent
+  ServerHeartbeatFailedEvent,
+  monitorServer
 };

--- a/lib/sdam/server.js
+++ b/lib/sdam/server.js
@@ -38,28 +38,13 @@ class Server extends EventEmitter {
       // the server logger
       logger: Logger('Server', options),
       // the bson parser
-      bson:
-        options.bson ||
-        new BSON([
-          BSON.Binary,
-          BSON.Code,
-          BSON.DBRef,
-          BSON.Decimal128,
-          BSON.Double,
-          BSON.Int32,
-          BSON.Long,
-          BSON.Map,
-          BSON.MaxKey,
-          BSON.MinKey,
-          BSON.ObjectId,
-          BSON.BSONRegExp,
-          BSON.Symbol,
-          BSON.Timestamp
-        ]),
+      bson: options.bson || new BSON(),
       // client metadata for the initial handshake
       clientInfo: createClientInfo(options),
       // state variable to determine if there is an active server check in progress
-      monitoring: false
+      monitoring: false,
+      // the connection pool
+      pool: null
     };
   }
 

--- a/lib/sdam/server.js
+++ b/lib/sdam/server.js
@@ -291,7 +291,7 @@ function executeWriteOperation(args, options, callback) {
   }
 
   // Execute write
-  return this.s.wireProtocolHandler[op](server.s.pool, ns, server.s.bson, ops, options, callback);
+  return server.s.wireProtocolHandler[op](server.s.pool, ns, server.s.bson, ops, options, callback);
 }
 
 function saslSupportedMechs(options) {

--- a/lib/sdam/server_selectors.js
+++ b/lib/sdam/server_selectors.js
@@ -10,14 +10,6 @@ const SMALLEST_MAX_STALENESS_SECONDS = 90;
 
 function writableServerSelector() {
   return function(topologyDescription, servers) {
-    if (topologyDescription === TopologyType.ReplicaSetNoPrimary) return [];
-    if (
-      topologyDescription.type === TopologyType.Sharded ||
-      topologyDescription.type === TopologyType.Single
-    ) {
-      return latencyWindowReducer(topologyDescription, servers);
-    }
-
     return latencyWindowReducer(topologyDescription, servers.filter(s => s.isWritable));
   };
 }

--- a/lib/sdam/topology.js
+++ b/lib/sdam/topology.js
@@ -395,8 +395,8 @@ function randomSelection(array) {
 
 /**
  * Selects servers using the provided selector
- * NOTE: this is an internal helper, not meant to be used directly
  *
+ * @private
  * @param {Topology} topology The topology to select servers from
  * @param {function} selector The actual predicate used for selecting servers
  * @param {Number} timeout The max time we are willing wait for selection
@@ -426,7 +426,7 @@ function selectServers(topology, selector, timeout, start, callback) {
   }
 
   const retrySelection = () => {
-    // ensure all server monitors are attempting monitoring immediately
+    // ensure all server monitors attempt monitoring immediately
     topology.s.servers.forEach(server => server.monitor());
 
     const iterationTimer = setTimeout(() => {

--- a/lib/sdam/topology.js
+++ b/lib/sdam/topology.js
@@ -414,12 +414,15 @@ function selectServers(topology, selector, timeout, start, callback) {
     return callback(null, servers);
   }
 
-  const duration = calculateDurationInMs(process.hrtime(start));
-  if (duration > timeout) {
+  const duration = calculateDurationInMs(start);
+  if (duration >= timeout) {
     return callback(new MongoTimeoutError(`Server selection timed out after ${timeout} ms`));
   }
 
-  // TODO: loop this, add monitoring
+  // TODO: we need to kick off requests to each monitor to check immediately before looping
+
+  // loop the server selection process
+  process.nextTick(() => selectServers(topology, selector, timeout, start, callback));
 }
 
 /**


### PR DESCRIPTION
NOTE: this builds on the previous PR so it will look a little huge until that is rebased.

Most notably here we introduce the ability to monitor servers, in order to keep the topology state machine up-to-date. A cool feature introduced, once monitoring was possible, is that we no longer have to explicitly call `connect` on a topology object.

This works:
```
it('should work without explicitly calling connect', function(done) {
  const config = this.configuration;
  const client = new Topology({ host: config.host, port: config.port });
  const ns = `${this.configuration.db}.insert_test`;

  client.insert(ns, { a: 1 }, function(err, result) {
    expect(err).to.not.exist;
    expect(result).to.exist;
    done();
  });
});
```