### PR TITLE
fix(wireprotocol): only send bypassDocumentValidation if true

### DIFF
--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -43,7 +43,7 @@ var executeWrite = function(pool, bson, type, opsField, ns, ops, options, callba
   }
 
   // Do we have bypassDocumentValidation set, then enable it on the write command
-  if (typeof options.bypassDocumentValidation === 'boolean') {
+  if (options.bypassDocumentValidation === true) {
     writeCommand.bypassDocumentValidation = options.bypassDocumentValidation;
   }
 

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -101,7 +101,7 @@ var executeWrite = function(pool, bson, type, opsField, ns, ops, options, callba
   }
 
   // Do we have bypassDocumentValidation set, then enable it on the write command
-  if (typeof options.bypassDocumentValidation === 'boolean') {
+  if (options.bypassDocumentValidation === true) {
     writeCommand.bypassDocumentValidation = options.bypassDocumentValidation;
   }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mongodb-mock-server": "^1.0.0",
     "mongodb-test-runner": "^1.1.18",
     "prettier": "~1.12.0",
+    "sinon": "^6.0.0",
     "snappy": "^6.0.1"
   },
   "peerOptionalDependencies": {

--- a/test/tests/unit/wire_protocol_test.js
+++ b/test/tests/unit/wire_protocol_test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const expect = require('chai').expect;
+const bson = require('bson');
+const wireProtocol2_6 = require('../../../lib/wireprotocol/2_6_support.js');
+const wireProtocol3_2 = require('../../../lib/wireprotocol/3_2_support.js');
+
+const MockPool = {};
+
+MockPool.write = function(cmd, options, callback) {
+  callback(null, cmd);
+};
+
+describe('WireProtocol', function() {
+  it('2.6 should only set bypassDocumentValidation to true if explicitly set by user to true', function(done) {
+    const options = { bypassDocumentValidation: true };
+    wireProtocol2_6.prototype.insert(MockPool, '', '', bson, 'ops', options, function(err, data) {
+      if (err) {
+        done(err);
+      }
+      expect(data.query.bypassDocumentValidation).to.equal(true);
+      done();
+    });
+  });
+
+  it('2.6 should not set bypassDocumentValidation to true if not explicitly set by user to true', function(done) {
+    const options = { bypassDocumentValidation: false };
+    wireProtocol2_6.prototype.insert(MockPool, '', '', bson, 'ops', options, function(err, data) {
+      if (err) {
+        done(err);
+      }
+      expect(data.query.bypassDocumentValidation).to.equal(undefined);
+      done();
+    });
+  });
+
+  it('3.2 should only set bypassDocumentValidation to true if explicitly set by user to true', function(done) {
+    const options = { bypassDocumentValidation: true };
+    wireProtocol3_2.prototype.insert(MockPool, '', '', bson, 'ops', options, function(err, data) {
+      if (err) {
+        done(err);
+      }
+      expect(data.query.bypassDocumentValidation).to.equal(true);
+      done();
+    });
+  });
+
+  it('3.2 should not set bypassDocumentValidation to true if not explicitly set by user to true', function(done) {
+    const options = { bypassDocumentValidation: false };
+    wireProtocol3_2.prototype.insert(MockPool, '', '', bson, 'ops', options, function(err, data) {
+      if (err) {
+        done(err);
+      }
+      expect(data.query.bypassDocumentValidation).to.equal(undefined);
+      done();
+    });
+  });
+});

--- a/test/tests/unit/wire_protocol_test.js
+++ b/test/tests/unit/wire_protocol_test.js
@@ -1,58 +1,55 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
+const expect = chai.expect;
 const bson = require('bson');
+const sinon = require('sinon');
+const Pool = require('../../../lib/connection/pool.js');
 const wireProtocol2_6 = require('../../../lib/wireprotocol/2_6_support.js');
 const wireProtocol3_2 = require('../../../lib/wireprotocol/3_2_support.js');
 
-const MockPool = {};
-
-MockPool.write = function(cmd, options, callback) {
-  callback(null, cmd);
+const fake_topology = 'fake_topology';
+const fake_bson = {
+  serialize: () => {},
+  deserialize: () => {}
 };
 
+const pool = new Pool(fake_topology, { bson: fake_bson });
+sinon.stub(pool, 'write');
+
 describe('WireProtocol', function() {
-  it('2.6 should only set bypassDocumentValidation to true if explicitly set by user to true', function(done) {
-    const options = { bypassDocumentValidation: true };
-    wireProtocol2_6.prototype.insert(MockPool, '', '', bson, 'ops', options, function(err, data) {
-      if (err) {
-        done(err);
-      }
-      expect(data.query.bypassDocumentValidation).to.equal(true);
-      done();
-    });
+  it('2.6 should only set bypassDocumentValidation to true if explicitly set by user to true', function() {
+    testPoolWrite(true, new wireProtocol2_6(), true);
   });
 
-  it('2.6 should not set bypassDocumentValidation to true if not explicitly set by user to true', function(done) {
-    const options = { bypassDocumentValidation: false };
-    wireProtocol2_6.prototype.insert(MockPool, '', '', bson, 'ops', options, function(err, data) {
-      if (err) {
-        done(err);
-      }
-      expect(data.query.bypassDocumentValidation).to.equal(undefined);
-      done();
-    });
+  it('2.6 should not set bypassDocumentValidation to anything if not explicitly set by user to true', function() {
+    testPoolWrite(false, new wireProtocol2_6(), undefined);
   });
 
-  it('3.2 should only set bypassDocumentValidation to true if explicitly set by user to true', function(done) {
-    const options = { bypassDocumentValidation: true };
-    wireProtocol3_2.prototype.insert(MockPool, '', '', bson, 'ops', options, function(err, data) {
-      if (err) {
-        done(err);
-      }
-      expect(data.query.bypassDocumentValidation).to.equal(true);
-      done();
-    });
+  it('3.2 should only set bypassDocumentValidation to true if explicitly set by user to true', function() {
+    testPoolWrite(true, new wireProtocol3_2(), true);
   });
 
-  it('3.2 should not set bypassDocumentValidation to true if not explicitly set by user to true', function(done) {
-    const options = { bypassDocumentValidation: false };
-    wireProtocol3_2.prototype.insert(MockPool, '', '', bson, 'ops', options, function(err, data) {
-      if (err) {
-        done(err);
-      }
-      expect(data.query.bypassDocumentValidation).to.equal(undefined);
-      done();
-    });
+  it('3.2 should not set bypassDocumentValidation to anything if not explicitly set by user to true', function() {
+    testPoolWrite(false, new wireProtocol3_2(), undefined);
   });
+
+  function testPoolWrite(bypassDocumentValidation, wireProtocol, expected) {
+    const isMaster = {};
+    const ns = 'fake.namespace';
+    const ops = 'fake.ops';
+    const options = { bypassDocumentValidation: bypassDocumentValidation };
+
+    wireProtocol.insert(pool, isMaster, ns, bson, ops, options, () => {});
+
+    if (expected) {
+      expect(pool.write.lastCall.args[0])
+        .to.have.nested.property('query.bypassDocumentValidation')
+        .that.equals(expected);
+    } else {
+      expect(pool.write.lastCall.args[0]).to.not.have.nested.property(
+        'query.bypassDocumentValidation'
+      );
+    }
+  }
 });

--- a/test/tests/unit/wire_protocol_test.js
+++ b/test/tests/unit/wire_protocol_test.js
@@ -8,15 +8,6 @@ const Pool = require('../../../lib/connection/pool.js');
 const wireProtocol2_6 = require('../../../lib/wireprotocol/2_6_support.js');
 const wireProtocol3_2 = require('../../../lib/wireprotocol/3_2_support.js');
 
-const fake_topology = 'fake_topology';
-const fake_bson = {
-  serialize: () => {},
-  deserialize: () => {}
-};
-
-const pool = new Pool(fake_topology, { bson: fake_bson });
-sinon.stub(pool, 'write');
-
 describe('WireProtocol', function() {
   it('2.6 should only set bypassDocumentValidation to true if explicitly set by user to true', function() {
     testPoolWrite(true, new wireProtocol2_6(), true);
@@ -35,9 +26,10 @@ describe('WireProtocol', function() {
   });
 
   function testPoolWrite(bypassDocumentValidation, wireProtocol, expected) {
+    const pool = sinon.createStubInstance(Pool);
     const isMaster = {};
     const ns = 'fake.namespace';
-    const ops = 'fake.ops';
+    const ops = [{ a: 1 }, { b: 2 }];
     const options = { bypassDocumentValidation: bypassDocumentValidation };
 
     wireProtocol.insert(pool, isMaster, ns, bson, ops, options, () => {});


### PR DESCRIPTION
The bypassDocumentValidation key will only be set if it explicitly
receives a true, otherwise it remains undefined.

Fixes NODE-1492