### PR TITLE
Do not force keys to lower case in URL parser

### DIFF
--- a/lib/uri_parser.js
+++ b/lib/uri_parser.js
@@ -173,7 +173,7 @@ function parseQueryString(query) {
       return new MongoParseError('Incomplete key value pair for option');
     }
 
-    result[key.toLowerCase()] = parseQueryStringItemValue(value);
+    result[key] = parseQueryStringItemValue(value);
   }
 
   // special cases for known deprecated options


### PR DESCRIPTION
Addresses issue in NODE-1542.

The URL Parser sets all keys to lowercase, which causes something like this:
`...?replicaSet=rs` to become `replicaset: rs`, effectively making any camelCased option undefined.