### PR TITLE
fix(pool): don't try to reconnect if initial connection fails

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -273,7 +273,7 @@ function reauthenticate(pool, connection, cb) {
   authenticateAgainstProvider(pool, connection, Object.keys(pool.authProviders), cb);
 }
 
-function connectionFailureHandler(self, event) {
+function connectionFailureHandler(self, event, skipReconnect) {
   return function(err) {
     if (this._connectionFailHandled) return;
     this._connectionFailHandled = true;
@@ -317,7 +317,7 @@ function connectionFailureHandler(self, event) {
     }
 
     // Start reconnection attempts
-    if (!self.reconnectId && self.options.reconnect) {
+    if (!self.reconnectId && self.options.reconnect && !skipReconnect) {
       self.reconnectId = setTimeout(attemptReconnect(self), self.options.reconnectInterval);
     }
 
@@ -759,9 +759,9 @@ Pool.prototype.connect = function() {
   });
 
   // Add error handlers
-  connection.once('error', connectionFailureHandler(this, 'error'));
-  connection.once('close', connectionFailureHandler(this, 'close'));
-  connection.once('timeout', connectionFailureHandler(this, 'timeout'));
+  connection.once('error', connectionFailureHandler(this, 'error', true));
+  connection.once('close', connectionFailureHandler(this, 'close', true));
+  connection.once('timeout', connectionFailureHandler(this, 'timeout', true));
   connection.once('parseError', connectionFailureHandler(this, 'parseError'));
 
   try {


### PR DESCRIPTION
Automattic/mongoose#6670 seems to be another instance of the issue I mentioned in #275: if initial connection fails, the driver will keep trying to reconnect in the background. So users that retry `MongoClient.connect()` when initial connection fails get a bunch of zombie database connections (one might call them "dead pools" :) ) if one of their reconnect tries succeeds. For example, try running this code against a standalone server that isn't running, and then start it after 10 seconds, you'll see 11 connections rather than 1.

```javascript
var mongodb = require('mongodb').MongoClient;

var url = 'mongodb://localhost:27017/edata';
var options = {
        useNewUrlParser: true,
        autoReconnect: true,
        poolSize: 3,
        reconnectTries: Number.MAX_VALUE,
        reconnectInterval: 1000,
        socketTimeoutMS: 5000
}
var conectDate = new Date();
var count = 0;


// Connect to the db
var connectWithRetry = function () {
        mongodb.connect(url, options, function (err, db) {

                
                if (!err) {
                        console.log("We are connected");
                        db.on('close', function () {
                                console.log('Close + ' + count);

                        })
                        db.on('reconnect', function () {
                                console.log('Reconnect')
                        })
                }
                else {
                        setTimeout(connectWithRetry, 1000);
                        count++;
                        console.log(conectDate + ' - Database not connected - ' + count);
                }
        });
}

connectWithRetry();
```

Just wanted to put this issue out there and suggest a potential fix. We need a consistent explanation for how to handle initial connection failures: either the driver will keep trying to reconnect, or the user should try to reconnect on their own. Right now we generally recommend the latter, but the code does a little bit of both the latter and the former.