### PR TITLE
fix(mongos): fix connection leak when mongos reconnects

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -1004,6 +1004,8 @@ var listeners = ['close', 'error', 'timeout', 'parseError', 'connect'];
  * @param {boolean} [options.force=false] Force destroy the pool
  */
 Server.prototype.destroy = function(options) {
+  if (this._destroyed) return;
+
   options = options || {};
   var self = this;
 
@@ -1016,7 +1018,10 @@ Server.prototype.destroy = function(options) {
   }
 
   // No pool, return
-  if (!self.s.pool) return;
+  if (!self.s.pool) {
+    this._destroyed = true;
+    return;
+  }
 
   // Emit close event
   if (options.emitClose) {
@@ -1051,6 +1056,7 @@ Server.prototype.destroy = function(options) {
 
   // Destroy the pool
   this.s.pool.destroy(options.force);
+  this._destroyed = true;
 };
 
 /**

--- a/test/tests/unit/mongos/reconnect_tests.js
+++ b/test/tests/unit/mongos/reconnect_tests.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const Mongos = require('../../../../lib/topologies/mongos');
+const expect = require('chai').expect;
+const mock = require('mongodb-mock-server');
+const genClusterTime = require('../common').genClusterTime;
+
+const Connection = require('../../../../lib/connection/connection');
+
+describe('Reconnect (Mongos)', function() {
+  const fixture = {};
+
+  function startServer() {
+    return mock.createServer(fixture.port).then(mockServer => {
+      mockServer.setMessageHandler(request => {
+        request.reply(
+          Object.assign({}, mock.DEFAULT_ISMASTER, {
+            $clusterTime: genClusterTime(Date.now()),
+            msg: 'isdbgrid'
+          })
+        );
+      });
+      fixture.server = mockServer;
+      fixture.port = mockServer.port;
+    });
+  }
+
+  function stopServer() {
+    return mock.cleanup();
+  }
+
+  beforeEach(() => startServer());
+  beforeEach(() => Connection.enableConnectionAccounting());
+  afterEach(() => Connection.disableConnectionAccounting());
+  afterEach(() => stopServer());
+
+  it('should not connection swarm when reconnecting', function(done) {
+    const reconnectInterval = 500;
+    const socketTimeout = reconnectInterval * 5;
+    const haInterval = reconnectInterval * 10;
+    const reconnectTries = Number.MAX_VALUE;
+
+    const connectOptions = {
+      haInterval,
+      reconnectInterval,
+      socketTimeout,
+      reconnectTries,
+      reconnect: true,
+      poolSize: 500
+    };
+
+    const mongos = new Mongos([fixture.server.address()], connectOptions);
+
+    function runIsMaster(assertion) {
+      return new Promise((resolve, reject) => {
+        mongos.command('admin.$cmd', { ismaster: 1 }, {}, (err, response) => {
+          try {
+            assertion(err, response);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+    }
+
+    function connectMongos() {
+      return new Promise((resolve, reject) => {
+        mongos.once('error', reject);
+        mongos.once('connect', resolve);
+        mongos.connect(connectOptions);
+      });
+    }
+
+    function assertSuccess(err, response) {
+      expect(err).to.not.exist;
+      expect(response).to.exist;
+    }
+
+    function assertError(err, response) {
+      expect(err).to.exist;
+      expect(response).to.not.exist;
+    }
+
+    function delay(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function cleanup(err) {
+      mongos.destroy();
+      return err;
+    }
+
+    Promise.resolve()
+      .then(() => connectMongos())
+      .then(() => runIsMaster(assertSuccess))
+      .then(() => stopServer())
+      .then(() => runIsMaster(assertError))
+      .then(() => delay(haInterval * 2))
+      .then(() => startServer())
+      .then(() => delay(haInterval * 2))
+      .then(() => expect(Object.keys(Connection.connections())).to.have.a.lengthOf(1))
+      .then(() => cleanup(), cleanup)
+      .then(done);
+  });
+});


### PR DESCRIPTION
Our mongos reconnect logic involved creating a new Server+Pool
per proxy per iteration of the reconnect logic. These instances
were never cleaned up, resulting in a huge number of connections
when the proxies finally reconnected.

Fixes NODE-1403

~WIP b/c I am trying to figure out how to test this.~ I have a test now. It takes a long time though :(