### PR TITLE
fix(uri-parser): Incorrect parsing of arrays

### DIFF
--- a/lib/uri_parser.js
+++ b/lib/uri_parser.js
@@ -137,7 +137,7 @@ function parseSrvConnectionString(uri, options, callback) {
 function parseQueryStringItemValue(value) {
   if (Array.isArray(value)) {
     // deduplicate and simplify arrays
-    value = value.filter((value, idx) => value.indexOf(value) === idx);
+    value = value.filter((v, idx) => value.indexOf(v) === idx);
     if (value.length === 1) value = value[0];
   } else if (value.indexOf(':') > 0) {
     value = value.split(',').reduce((result, pair) => {

--- a/test/tests/unit/connection_string_spec_tests.js
+++ b/test/tests/unit/connection_string_spec_tests.js
@@ -32,6 +32,14 @@ describe('Connection String (spec)', function() {
     });
   });
 
+  it('should correctly parse arrays', function(done) {
+    parseConnectionString('mongodb://hostname?foo=bar&foo=baz', function(err, result) {
+      expect(err).to.not.exist;
+      expect(result.options.foo).to.deep.equal(['bar', 'baz']);
+      done();
+    });
+  });
+
   const testFiles = fs
     .readdirSync(f('%s/../spec/connection-string', __dirname))
     .filter(x => x.indexOf('.json') !== -1)


### PR DESCRIPTION
Arrays passed in to the uri string by repeating fields
are now parsed correctly.

Fixes NODE-1605