### PR TITLE
fix(cursor): typo in _find() cursor validation

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -238,7 +238,7 @@ Cursor.prototype._find = function(callback) {
       Array.isArray(result.documents) &&
       result.documents.length === 1 &&
       (!self.cmd.find || (self.cmd.find && self.cmd.virtual === false)) &&
-      (result.documents[0].cursor !== 'string' ||
+      (typeof result.documents[0].cursor !== 'string' ||
         result.documents[0]['$err'] ||
         result.documents[0]['errmsg'] ||
         Array.isArray(result.documents[0].result))


### PR DESCRIPTION
This PR fixes a typo in the `_find()` function when validating the results cursor.

A type check is lacking the `typeof` operator (line 241).
It is written correctly a few lines below (line 252).

/cc @christkv (author of this code)