### PR TITLE
fix(uri-parser): Parse comma-separated option values

### DIFF
--- a/lib/uri_parser.js
+++ b/lib/uri_parser.js
@@ -145,6 +145,10 @@ function parseQueryStringItemValue(value) {
       result[parts[0]] = parseQueryStringItemValue(parts[1]);
       return result;
     }, {});
+  } else if (value.indexOf(',') > 0) {
+    value = value.split(',').map(v => {
+      return parseQueryStringItemValue(v);
+    });
   } else if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
     value = value.toLowerCase() === 'true';
   } else if (!Number.isNaN(value)) {


### PR DESCRIPTION
Enable parsing of comma-separated option values into arrays.

Fixes NODE-1612