### PR TITLE
refactor(topologies): rename `getServer` to `selectServer`

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -1280,24 +1280,23 @@ Mongos.prototype.logout = function(dbName, callback) {
 };
 
 /**
- * Get server
+ * Selects a server
+ *
  * @method
- * @return {Server}
+ * @param {function} selector Unused
+ * @param {ReadPreference} [options.readPreference] Specify read preference if command supports it
+ * @param {function} callback
  */
-Mongos.prototype.getServer = function() {
-  var server = pickProxy(this);
-  if (this.s.debug) this.emit('pickedServer', null, server);
-  return server;
-};
+Mongos.prototype.selectServer = function(selector, options, callback) {
+  if (typeof selector === 'function' && typeof callback === 'undefined')
+    (callback = selector), (selector = undefined), (options = {});
+  if (typeof options === 'function')
+    (callback = options), (options = selector), (selector = undefined);
+  options = options || {};
 
-/**
- * Get a direct connection
- * @method
- * @return {Connection}
- */
-Mongos.prototype.getConnection = function() {
-  var server = this.getServer();
-  if (server) return server.getConnection();
+  const server = pickProxy(this);
+  if (this.s.debug) this.emit('pickedServer', null, server);
+  callback(null, server);
 };
 
 /**

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1130,29 +1130,23 @@ ReplSet.prototype.isDestroyed = function() {
 };
 
 /**
- * Get server
+ * Selects a server
+ *
  * @method
+ * @param {function} selector Unused
  * @param {ReadPreference} [options.readPreference] Specify read preference if command supports it
- * @return {Server}
+ * @param {function} callback
  */
-ReplSet.prototype.getServer = function(options) {
-  // Ensure we have no options
+ReplSet.prototype.selectServer = function(selector, options, callback) {
+  if (typeof selector === 'function' && typeof callback === 'undefined')
+    (callback = selector), (selector = undefined), (options = {});
+  if (typeof options === 'function')
+    (callback = options), (options = selector), (selector = undefined);
   options = options || {};
-  // Pick the right server based on readPreference
-  var server = this.s.replicaSetState.pickServer(options.readPreference);
-  if (this.s.debug) this.emit('pickedServer', options.readPreference, server);
-  return server;
-};
 
-/**
- * Get a direct connection
- * @method
- * @param {ReadPreference} [options.readPreference] Specify read preference if command supports it
- * @return {Connection}
- */
-ReplSet.prototype.getConnection = function(options) {
-  var server = this.getServer(options);
-  if (server) return server.getConnection();
+  const server = this.s.replicaSetState.pickServer(options.readPreference);
+  if (this.s.debug) this.emit('pickedServer', options.readPreference, server);
+  callback(null, server);
 };
 
 /**

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -979,21 +979,16 @@ Server.prototype.connections = function() {
 };
 
 /**
- * Get server
- * @method
+ * Selects a server
  * @return {Server}
  */
-Server.prototype.getServer = function() {
-  return this;
-};
+Server.prototype.selectServer = function(selector, options, callback) {
+  if (typeof selector === 'function' && typeof callback === 'undefined')
+    (callback = selector), (selector = undefined), (options = {});
+  if (typeof options === 'function')
+    (callback = options), (options = selector), (selector = undefined);
 
-/**
- * Get connection
- * @method
- * @return {Connection}
- */
-Server.prototype.getConnection = function() {
-  return this.s.pool.get();
+  callback(null, this);
 };
 
 var listeners = ['close', 'error', 'timeout', 'parseError', 'connect'];


### PR DESCRIPTION
This makes it much easier to drop-in replace the upcoming unified
`Topology` type by making the internal APIs the same.

NODE-1625