### PR TITLE
fix(buffer): use safe-buffer polyfill to maintain compatibility

### DIFF
--- a/lib/auth/scram.js
+++ b/lib/auth/scram.js
@@ -4,7 +4,8 @@ var f = require('util').format,
   crypto = require('crypto'),
   retrieveBSON = require('../connection/utils').retrieveBSON,
   Query = require('../connection/commands').Query,
-  MongoError = require('../error').MongoError;
+  MongoError = require('../error').MongoError,
+  Buffer = require('safe-buffer').Buffer;
 
 let saslprep;
 

--- a/lib/connection/commands.js
+++ b/lib/connection/commands.js
@@ -4,6 +4,7 @@ var retrieveBSON = require('./utils').retrieveBSON;
 var BSON = retrieveBSON();
 var Long = BSON.Long;
 const MongoError = require('../error').MongoError;
+const Buffer = require('safe-buffer').Buffer;
 
 // Incrementing request id
 var _requestId = 0;

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -13,7 +13,8 @@ var inherits = require('util').inherits,
   MongoNetworkError = require('../error').MongoNetworkError,
   Logger = require('./logger'),
   OP_COMPRESSED = require('../wireprotocol/shared').opcodes.OP_COMPRESSED,
-  MESSAGE_HEADER_SIZE = require('../wireprotocol/shared').MESSAGE_HEADER_SIZE;
+  MESSAGE_HEADER_SIZE = require('../wireprotocol/shared').MESSAGE_HEADER_SIZE,
+  Buffer = require('safe-buffer').Buffer;
 
 var _id = 0;
 var debugFields = [

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -18,6 +18,7 @@ const uncompressibleCommands = require('../wireprotocol/compression').uncompress
 const resolveClusterTime = require('../topologies/shared').resolveClusterTime;
 const apm = require('./apm');
 const defaultAuthProviders = require('../auth/defaultAuthProviders').defaultAuthProviders;
+const Buffer = require('safe-buffer').Buffer;
 
 var DISCONNECTED = 'disconnected';
 var CONNECTING = 'connecting';

--- a/lib/topologies/replset_state.js
+++ b/lib/topologies/replset_state.js
@@ -6,7 +6,8 @@ var inherits = require('util').inherits,
   EventEmitter = require('events').EventEmitter,
   Logger = require('../connection/logger'),
   ReadPreference = require('./read_preference'),
-  MongoError = require('../error').MongoError;
+  MongoError = require('../error').MongoError,
+  Buffer = require('safe-buffer').Buffer;
 
 var TopologyType = {
   Single: 'Single',

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -3,6 +3,7 @@
 const os = require('os');
 const f = require('util').format;
 const ReadPreference = require('./read_preference');
+const Buffer = require('safe-buffer').Buffer;
 
 /**
  * Emit event if it exists

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "mongodb-core",
+  "version": "3.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "dependencies": {
     "bson": "^1.1.0",
-    "require_optional": "^1.0.1"
+    "require_optional": "^1.0.1",
+    "safe-buffer": "^5.1.2"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -7,6 +7,7 @@ const Server = require('../../../lib/topologies/server');
 const Bson = require('bson');
 const Connection = require('../../../lib/connection/connection');
 const mock = require('mongodb-mock-server');
+const Buffer = require('safe-buffer').Buffer;
 
 describe('Server tests', function() {
   it('should correctly connect server to single instance', {

--- a/test/tests/unit/common.js
+++ b/test/tests/unit/common.js
@@ -4,6 +4,7 @@ const mock = require('mongodb-mock-server');
 const ObjectId = require('bson').ObjectId;
 const Timestamp = require('bson').Timestamp;
 const Binary = require('bson').Binary;
+const Buffer = require('safe-buffer').Buffer;
 
 class ReplSetFixture {
   constructor() {

--- a/test/tests/unit/scram_iterations_tests.js
+++ b/test/tests/unit/scram_iterations_tests.js
@@ -3,6 +3,7 @@
 const expect = require('chai').expect;
 const mock = require('mongodb-mock-server');
 const Server = require('../../../lib/topologies/server');
+const Buffer = require('safe-buffer').Buffer;
 
 describe('SCRAM Iterations Tests', function() {
   const test = {};


### PR DESCRIPTION
Hi,

The fix of [NODE-1461](https://jira.mongodb.org/projects/NODE/issues/NODE-1461?filter=allissues) ( commit 7c71e199190a53017b921e88200cdba3889ca23c) break compatibility with node.js < 4.5 and node.js < 5.9 and  and start to affect downstream packages like Automattic/mongoose#6884

This pull request uses `safe-buffer` to polyfill and [it is suggested by official node.js](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/)

The polyfill won't change any existing behavior and will call native method directly if it is supported.