### PR TITLE
 test(*): use `newTopology` instead of explicitly creating Servers

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -15,11 +15,17 @@ class CoreConfiguration extends ConfigurationBase {
     this.topology = options.topology || this.defaultTopology;
   }
 
-  defaultTopology(self, _mongo) {
-    return new _mongo.Server({
-      host: self.host,
-      port: self.port
-    });
+  defaultTopology(self, _mongo, options) {
+    options = Object.assign(
+      {},
+      {
+        host: self.host,
+        port: self.port
+      },
+      options
+    );
+
+    return new _mongo.Server(options);
   }
 
   start(callback) {
@@ -62,13 +68,9 @@ class CoreConfiguration extends ConfigurationBase {
       });
   }
 
-  newTopology(opts, callback) {
-    if (typeof opts === 'function') {
-      callback = opts;
-      opts = {};
-    }
-
-    callback(null, this.topology(this, this.mongo));
+  newTopology(options) {
+    options = options || {};
+    return this.topology(this, this.mongo, options);
   }
 
   newConnection(opts, callback) {

--- a/test/tests/functional/basic_single_server_auth_tests.js
+++ b/test/tests/functional/basic_single_server_auth_tests.js
@@ -3,7 +3,6 @@
 var expect = require('chai').expect,
   locateAuthMethod = require('./shared').locateAuthMethod,
   executeCommand = require('./shared').executeCommand,
-  Server = require('../../../lib/topologies/server'),
   Connection = require('../../../lib/connection/connection'),
   Bson = require('bson');
 
@@ -44,7 +43,7 @@ describe('Basic single server auth tests', function() {
         expect(cmdErr).to.be.null;
         expect(r).to.exist;
 
-        const server = new Server({
+        const server = config.newTopology({
           host: this.configuration.host,
           port: this.configuration.port,
           bson: new Bson()
@@ -101,7 +100,7 @@ describe('Basic single server auth tests', function() {
               expect(r).to.exist;
               expect(cmdErr).to.be.null;
 
-              var server = new Server({
+              var server = this.configuration.newTopology({
                 host: self.configuration.host,
                 port: self.configuration.port,
                 bson: new Bson()
@@ -128,6 +127,7 @@ describe('Basic single server auth tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
 
       // Enable connections accounting
       Connection.enableConnectionAccounting();
@@ -150,7 +150,7 @@ describe('Basic single server auth tests', function() {
               expect(r).to.exist;
               expect(cmdErr).to.be.null;
 
-              var server = new Server({
+              var server = config.newTopology({
                 host: self.configuration.host,
                 port: self.configuration.port,
                 bson: new Bson()
@@ -197,6 +197,7 @@ describe('Basic single server auth tests', function() {
 
       test: function(done) {
         var self = this;
+        const config = this.configuration;
 
         // Enable connections accounting
         Connection.enableConnectionAccounting();
@@ -241,7 +242,7 @@ describe('Basic single server auth tests', function() {
                     expect(createUserErr).to.be.null;
 
                     // Attempt to connect
-                    var server = new Server({
+                    var server = config.newTopology({
                       host: self.configuration.host,
                       port: self.configuration.port,
                       bson: new Bson()
@@ -301,6 +302,7 @@ describe('Basic single server auth tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
 
       // Enable connections accounting
       Connection.enableConnectionAccounting();
@@ -345,7 +347,7 @@ describe('Basic single server auth tests', function() {
                   expect(createUserErr).to.be.null;
 
                   // Attempt to connect
-                  var server = new Server({
+                  var server = config.newTopology({
                     host: self.configuration.host,
                     port: self.configuration.port,
                     bson: new Bson()
@@ -419,6 +421,7 @@ describe('Basic single server auth tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
 
       // Enable connections accounting
       Connection.enableConnectionAccounting();
@@ -463,7 +466,7 @@ describe('Basic single server auth tests', function() {
                   expect(createUserErr).to.be.null;
 
                   // Attempt to connect
-                  var server = new Server({
+                  var server = config.newTopology({
                     host: self.configuration.host,
                     port: self.configuration.port,
                     bson: new Bson()
@@ -513,6 +516,7 @@ describe('Basic single server auth tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
 
       // Enable connections accounting
       Connection.enableConnectionAccounting();
@@ -556,7 +560,7 @@ describe('Basic single server auth tests', function() {
                   expect(createUserRes).to.exist;
                   expect(createUserErr).to.be.null;
                   // Attempt to connect
-                  var server = new Server({
+                  var server = config.newTopology({
                     host: self.configuration.host,
                     port: self.configuration.port,
                     bson: new Bson()

--- a/test/tests/functional/client_metadata_tests.js
+++ b/test/tests/functional/client_metadata_tests.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var expect = require('chai').expect,
-  Server = require('../../../lib/topologies/server'),
   Bson = require('bson'),
   Mongos = require('../../../lib/topologies/mongos');
 
@@ -11,7 +10,7 @@ describe('Client metadata tests', function() {
 
     test: function(done) {
       // Attempt to connect
-      var server = new Server({
+      var server = this.configuration.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson(),

--- a/test/tests/functional/cursor_tests.js
+++ b/test/tests/functional/cursor_tests.js
@@ -2,8 +2,6 @@
 
 const expect = require('chai').expect;
 const f = require('util').format;
-const Server = require('../../../lib/topologies/server');
-const Bson = require('bson');
 const setupDatabase = require('./shared').setupDatabase;
 
 describe('Cursor tests', function() {
@@ -17,14 +15,7 @@ describe('Cursor tests', function() {
     },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
-        host: this.configuration.host,
-        port: this.configuration.port,
-        bson: new Bson()
-      });
-
-      // Add event listeners
+      const server = this.configuration.newTopology();
       server.on('connect', function(_server) {
         var ns = f('integration_tests.cursor1');
         // Execute the write
@@ -78,13 +69,7 @@ describe('Cursor tests', function() {
     },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
-        host: this.configuration.host,
-        port: this.configuration.port,
-        bson: new Bson()
-      });
-
+      const server = this.configuration.newTopology();
       var ns = f('%s.cursor2', this.configuration.db);
       // Add event listeners
       server.on('connect', function(_server) {
@@ -142,13 +127,7 @@ describe('Cursor tests', function() {
     },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
-        host: this.configuration.host,
-        port: this.configuration.port,
-        bson: new Bson()
-      });
-
+      const server = this.configuration.newTopology();
       var ns = f('%s.cursor3', this.configuration.db);
       // Add event listeners
       server.on('connect', function(_server) {
@@ -202,13 +181,7 @@ describe('Cursor tests', function() {
     },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
-        host: this.configuration.host,
-        port: this.configuration.port,
-        bson: new Bson()
-      });
-
+      const server = this.configuration.newTopology();
       var ns = f('%s.cursor4', this.configuration.db);
       // Add event listeners
       server.on('connect', function(_server) {
@@ -262,13 +235,7 @@ describe('Cursor tests', function() {
     },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
-        host: this.configuration.host,
-        port: this.configuration.port,
-        bson: new Bson()
-      });
-
+      const server = this.configuration.newTopology();
       var ns = f('%s.cursor4', this.configuration.db);
       // Add event listeners
       server.on('connect', function(_server) {
@@ -398,13 +365,7 @@ describe('Cursor tests', function() {
     },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
-        host: this.configuration.host,
-        port: this.configuration.port,
-        bson: new Bson()
-      });
-
+      const server = this.configuration.newTopology();
       var ns = f('%s.cursor6', this.configuration.db);
       // Add event listeners
       server.on('connect', function(_server) {
@@ -464,17 +425,11 @@ describe('Cursor tests', function() {
 
   it('Should not leak connnection workItem elements when using killCursor', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded'] }
+      requires: { topology: ['single'] }
     },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
-        host: this.configuration.host,
-        port: this.configuration.port,
-        bson: new Bson()
-      });
-
+      const server = this.configuration.newTopology();
       var ns = f('%s.cursor4', this.configuration.db);
       // Add event listeners
       server.on('connect', function(_server) {

--- a/test/tests/functional/error_tests.js
+++ b/test/tests/functional/error_tests.js
@@ -14,21 +14,21 @@ describe('Error tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
 
-      self.configuration.newTopology(function(err, server) {
-        var ns = f('%s.geohaystack1', self.configuration.db);
-        server.on('connect', function(_server) {
-          _server.command('system.$cmd', { geoNear: ns }, {}, function(_err, result) {
-            expect(result).to.not.exist;
-            expect(/can't find ns/.test(_err)).to.be.ok;
-            _server.destroy();
-            done();
-          });
+      var ns = f('%s.geohaystack1', self.configuration.db);
+      server.on('connect', function(_server) {
+        _server.command('system.$cmd', { geoNear: ns }, {}, function(_err, result) {
+          expect(result).to.not.exist;
+          expect(/can't find ns/.test(_err)).to.be.ok;
+          _server.destroy();
+          done();
         });
-
-        // Start connection
-        server.connect();
       });
+
+      // Start connection
+      server.connect();
     }
   });
 

--- a/test/tests/functional/extend_cursor_tests.js
+++ b/test/tests/functional/extend_cursor_tests.js
@@ -7,13 +7,12 @@ var expect = require('chai').expect,
 describe('Extend cursor tests', function() {
   it('should correctly extend the cursor with custom implementation', {
     metadata: {
-      requires: { topology: ['single', 'replicaset', 'sharded'] }
+      requires: { topology: ['single'] }
     },
 
     test: function(done) {
       var self = this;
-
-      var Server = this.configuration.mongo.Server;
+      const config = this.configuration;
       var Cursor = this.configuration.mongo.Cursor;
 
       // Create an extended cursor that adds a toArray function
@@ -46,7 +45,7 @@ describe('Extend cursor tests', function() {
       inherits(ExtendedCursor, Cursor);
 
       // Attempt to connect, adding a custom cursor creator
-      var server = new Server({
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         cursorFactory: ExtendedCursor
@@ -71,6 +70,8 @@ describe('Extend cursor tests', function() {
               find: f('%s.inserts_extend_cursors', self.configuration.db),
               query: {}
             });
+
+            console.log(cursor);
 
             // Force a single
             // Logger.setLevel('debug');

--- a/test/tests/functional/max_staleness_tests.js
+++ b/test/tests/functional/max_staleness_tests.js
@@ -4,10 +4,10 @@ const expect = require('chai').expect,
   p = require('path'),
   f = require('util').format,
   fs = require('fs'),
+  Server = require('../../../lib/topologies/server'),
   ReplSetState = require('../../../lib/topologies/replset_state'),
   MongoError = require('../../../lib/error').MongoError,
-  ReadPreference = require('../../../lib/topologies/read_preference'),
-  Server = require('../../../lib/topologies/server');
+  ReadPreference = require('../../../lib/topologies/read_preference');
 
 const rsWithPrimaryPath = f('%s/../spec/max-staleness/ReplicaSetWithPrimary', __dirname);
 const rsWithoutPrimaryPath = f('%s/../spec/max-staleness/ReplicaSetNoPrimary', __dirname);
@@ -19,7 +19,7 @@ describe('Max Staleness', function() {
       .filter(x => x.indexOf('.json') !== -1)
       .forEach(x => {
         it(p.basename(x, '.json'), function(done) {
-          executeEntry(x, f('%s/%s', rsWithoutPrimaryPath, x), done);
+          executeEntry(f('%s/%s', rsWithoutPrimaryPath, x), done);
         });
       });
   });
@@ -31,7 +31,7 @@ describe('Max Staleness', function() {
       .filter(x => x.indexOf('LongHeartbeat2.json') === -1)
       .forEach(x => {
         it(p.basename(x, '.json'), function(done) {
-          executeEntry(x, f('%s/%s', rsWithPrimaryPath, x), done);
+          executeEntry(f('%s/%s', rsWithPrimaryPath, x), done);
         });
       });
   });
@@ -44,7 +44,7 @@ function convert(mode) {
   return mode.toLowerCase();
 }
 
-function executeEntry(entry, path, callback) {
+function executeEntry(path, callback) {
   // Read and parse the json file
   var file = require(path);
 

--- a/test/tests/functional/operation_example_tests.js
+++ b/test/tests/functional/operation_example_tests.js
@@ -23,10 +23,10 @@ describe('Server operation example tests', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.mongo.Server;
+      const config = this.configuration;
 
       // Attempt to connect
-      var server = new Server({
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: true,
@@ -79,10 +79,10 @@ describe('Server operation example tests', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.require.Server;
+      const config = this.configuration;
 
       // Attempt to connect
-      var server = new Server({
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: true,
@@ -154,10 +154,10 @@ describe('Server operation example tests', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.require.Server;
+      const config = this.configuration;
 
       // Attempt to connect
-      var server = new Server({
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: true,
@@ -229,10 +229,10 @@ describe('Server operation example tests', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.require.Server;
+      const config = this.configuration;
 
       // Attempt to connect
-      var server = new Server({
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: true,
@@ -297,10 +297,10 @@ describe('Server operation example tests', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.require.Server;
+      const config = this.configuration;
 
       // Attempt to connect
-      var server = new Server({
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: true,

--- a/test/tests/functional/operations_tests.js
+++ b/test/tests/functional/operations_tests.js
@@ -26,16 +26,15 @@ describe('Operation tests', function() {
     },
 
     test: function(done) {
-      this.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          _server.destroy();
-          done();
-        });
-
-        // Start connection
-        server.connect();
+      const config = this.configuration;
+      const server = config.newTopology();
+      server.on('connect', function(_server) {
+        _server.destroy();
+        done();
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -46,29 +45,29 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var ReadPreference = this.configuration.mongo.ReadPreference;
+      const config = this.configuration;
+      const server = config.newTopology();
 
-      this.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the command
-          _server.command(
-            'system.$cmd',
-            { ismaster: true },
-            { readPreference: new ReadPreference('primary') },
-            function(cmdErr, cmdRes) {
-              expect(cmdErr).to.be.null;
-              expect(cmdRes.result.ismaster).to.be.true;
-              // Destroy the connection
-              _server.destroy();
-              // Finish the test
-              done();
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Execute the command
+        _server.command(
+          'system.$cmd',
+          { ismaster: true },
+          { readPreference: new ReadPreference('primary') },
+          function(cmdErr, cmdRes) {
+            expect(cmdErr).to.be.null;
+            expect(cmdRes.result.ismaster).to.be.true;
+            // Destroy the connection
+            _server.destroy();
+            // Finish the test
+            done();
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -79,32 +78,30 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var self = this;
-
-      self.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the write
-          _server.insert(
-            f('%s.inserts', self.configuration.db),
-            [{ a: 1 }],
-            {
-              writeConcern: { w: 1 },
-              ordered: true
-            },
-            function(insertErr, insertResults) {
-              expect(insertErr).to.be.null;
-              expect(insertResults.result.n).to.equal(1);
-              // Destroy the connection
-              _server.destroy();
-              // Finish the test
-              done();
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+      const config = this.configuration;
+      const server = config.newTopology();
+      server.on('connect', function(_server) {
+        // Execute the write
+        _server.insert(
+          f('%s.inserts', self.configuration.db),
+          [{ a: 1 }],
+          {
+            writeConcern: { w: 1 },
+            ordered: true
+          },
+          function(insertErr, insertResults) {
+            expect(insertErr).to.be.null;
+            expect(insertResults.result.n).to.equal(1);
+            // Destroy the connection
+            _server.destroy();
+            // Finish the test
+            done();
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -115,60 +112,59 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
+      var ReadPreference = self.configuration.mongo.ReadPreference;
 
-      self.configuration.newTopology(function(err, server) {
-        var ReadPreference = self.configuration.mongo.ReadPreference;
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Execute the write
+        _server.insert(
+          f('%s.inserts1', self.configuration.db),
+          [{ a: 1 }],
+          {
+            writeConcern: { w: 1 },
+            ordered: true
+          },
+          function(insertErr, insertResults) {
+            expect(insertResults).to.exist;
+            expect(insertErr).to.be.null;
 
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the write
-          _server.insert(
-            f('%s.inserts1', self.configuration.db),
-            [{ a: 1 }],
-            {
-              writeConcern: { w: 1 },
-              ordered: true
-            },
-            function(insertErr, insertResults) {
-              expect(insertResults).to.exist;
-              expect(insertErr).to.be.null;
+            // Work around 2.4.x issue with mongos reporting write done but it has
+            // not actually been written to the primary in the shard yet
+            setTimeout(function() {
+              // Execute find
+              var cursor = _server.cursor(
+                f('%s.inserts1', self.configuration.db),
+                {
+                  find: f('%s.inserts1', self.configuration.db),
+                  query: {}
+                },
+                { readPreference: ReadPreference.primary }
+              );
 
-              // Work around 2.4.x issue with mongos reporting write done but it has
-              // not actually been written to the primary in the shard yet
-              setTimeout(function() {
-                // Execute find
-                var cursor = _server.cursor(
-                  f('%s.inserts1', self.configuration.db),
-                  {
-                    find: f('%s.inserts1', self.configuration.db),
-                    query: {}
-                  },
-                  { readPreference: ReadPreference.primary }
-                );
+              // Execute next
+              cursor.next(function(cursorErr, cursorD) {
+                expect(cursorErr).to.be.null;
+                expect(cursorD.a).to.equal(1);
 
                 // Execute next
-                cursor.next(function(cursorErr, cursorD) {
-                  expect(cursorErr).to.be.null;
-                  expect(cursorD.a).to.equal(1);
-
-                  // Execute next
-                  cursor.next(function(secondCursorErr, secondCursorD) {
-                    expect(secondCursorErr).to.be.null;
-                    expect(secondCursorD).to.be.null;
-                    // Destroy the server connection
-                    _server.destroy();
-                    // Finish the test
-                    done();
-                  });
+                cursor.next(function(secondCursorErr, secondCursorD) {
+                  expect(secondCursorErr).to.be.null;
+                  expect(secondCursorD).to.be.null;
+                  // Destroy the server connection
+                  _server.destroy();
+                  // Finish the test
+                  done();
                 });
-              }, 1000);
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+              });
+            }, 1000);
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -178,63 +174,62 @@ describe('Operation tests', function() {
     },
 
     test: function(done) {
-      var self = this;
+      const self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
+      var ReadPreference = self.configuration.mongo.ReadPreference;
 
-      self.configuration.newTopology(function(err, server) {
-        var ReadPreference = self.configuration.mongo.ReadPreference;
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Execute the write
+        _server.insert(
+          f('%s.inserts12', self.configuration.db),
+          [{ a: 1 }, { a: 2 }, { a: 3 }],
+          {
+            writeConcern: { w: 1 },
+            ordered: true
+          },
+          function(insertErr, insertResults) {
+            expect(insertResults).to.exist;
+            expect(insertErr).to.be.null;
 
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the write
-          _server.insert(
-            f('%s.inserts12', self.configuration.db),
-            [{ a: 1 }, { a: 2 }, { a: 3 }],
-            {
-              writeConcern: { w: 1 },
-              ordered: true
-            },
-            function(insertErr, insertResults) {
-              expect(insertResults).to.exist;
-              expect(insertErr).to.be.null;
+            // Work around 2.4.x issue with mongos reporting write done but it has
+            // not actually been written to the primary in the shard yet
+            setTimeout(function() {
+              // Execute find
+              var cursor = _server.cursor(
+                f('%s.inserts12', self.configuration.db),
+                {
+                  find: f('%s.inserts12', self.configuration.db),
+                  query: {},
+                  limit: 1,
+                  skip: 1
+                },
+                { readPreference: ReadPreference.primary }
+              );
 
-              // Work around 2.4.x issue with mongos reporting write done but it has
-              // not actually been written to the primary in the shard yet
-              setTimeout(function() {
-                // Execute find
-                var cursor = _server.cursor(
-                  f('%s.inserts12', self.configuration.db),
-                  {
-                    find: f('%s.inserts12', self.configuration.db),
-                    query: {},
-                    limit: 1,
-                    skip: 1
-                  },
-                  { readPreference: ReadPreference.primary }
-                );
+              // Execute next
+              cursor.next(function(cursorErr, cursorD) {
+                expect(cursorErr).to.be.null;
+                expect(cursorD.a).to.equal(2);
 
                 // Execute next
-                cursor.next(function(cursorErr, cursorD) {
-                  expect(cursorErr).to.be.null;
-                  expect(cursorD.a).to.equal(2);
-
-                  // Execute next
-                  cursor.next(function(secondCursorErr, secondCursorD) {
-                    expect(secondCursorErr).to.be.null;
-                    expect(secondCursorD).to.be.null;
-                    // Destroy the server connection
-                    _server.destroy();
-                    // Finish the test
-                    done();
-                  });
+                cursor.next(function(secondCursorErr, secondCursorD) {
+                  expect(secondCursorErr).to.be.null;
+                  expect(secondCursorD).to.be.null;
+                  // Destroy the server connection
+                  _server.destroy();
+                  // Finish the test
+                  done();
                 });
-              }, 1000);
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+              });
+            }, 1000);
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -245,57 +240,56 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
+      var ReadPreference = self.configuration.mongo.ReadPreference;
 
-      self.configuration.newTopology(function(err, server) {
-        var ReadPreference = self.configuration.mongo.ReadPreference;
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Execute the write
+        _server.insert(
+          f('%s.inserts_result_1', self.configuration.db),
+          [{ a: 1, result: [{ c: 1 }, { c: 2 }] }],
+          {
+            writeConcern: { w: 1 },
+            ordered: true
+          },
+          function(insertErr, insertResults) {
+            expect(insertResults).to.exist;
+            expect(insertErr).to.be.null;
 
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the write
-          _server.insert(
-            f('%s.inserts_result_1', self.configuration.db),
-            [{ a: 1, result: [{ c: 1 }, { c: 2 }] }],
-            {
-              writeConcern: { w: 1 },
-              ordered: true
-            },
-            function(insertErr, insertResults) {
-              expect(insertResults).to.exist;
-              expect(insertErr).to.be.null;
+            // Work around 2.4.x issue with mongos reporting write done but it has
+            // not actually been written to the primary in the shard yet
+            setTimeout(function() {
+              // Execute find
+              var cursor = _server.cursor(
+                f('%s.inserts_result_1', self.configuration.db),
+                {
+                  find: f('%s.inserts_result_1', self.configuration.db),
+                  query: {}
+                },
+                { readPreference: ReadPreference.primary }
+              );
 
-              // Work around 2.4.x issue with mongos reporting write done but it has
-              // not actually been written to the primary in the shard yet
-              setTimeout(function() {
-                // Execute find
-                var cursor = _server.cursor(
-                  f('%s.inserts_result_1', self.configuration.db),
-                  {
-                    find: f('%s.inserts_result_1', self.configuration.db),
-                    query: {}
-                  },
-                  { readPreference: ReadPreference.primary }
-                );
+              // Execute next
+              cursor.next(function(cursorErr, cursorD) {
+                expect(cursorErr).to.be.null;
+                expect(cursorD.a).to.equal(1);
+                expect(cursorD.result[0].c).to.equal(1);
+                expect(cursorD.result[1].c).to.equal(2);
 
-                // Execute next
-                cursor.next(function(cursorErr, cursorD) {
-                  expect(cursorErr).to.be.null;
-                  expect(cursorD.a).to.equal(1);
-                  expect(cursorD.result[0].c).to.equal(1);
-                  expect(cursorD.result[1].c).to.equal(2);
-
-                  // Destroy the server connection
-                  _server.destroy();
-                  // Finish the test
-                  done();
-                });
-              }, 1000);
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+                // Destroy the server connection
+                _server.destroy();
+                // Finish the test
+                done();
+              });
+            }, 1000);
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -309,57 +303,57 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
 
-      self.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the write
-          _server.insert(
-            f('%s.inserts10', self.configuration.db),
-            [{ a: 1 }, { a: 2 }, { a: 3 }],
-            {
-              writeConcern: { w: 1 },
-              ordered: true
-            },
-            function(insertErr, insertResults) {
-              expect(insertErr).to.be.null;
-              expect(insertResults.result.n).to.equal(3);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Execute the write
+        _server.insert(
+          f('%s.inserts10', self.configuration.db),
+          [{ a: 1 }, { a: 2 }, { a: 3 }],
+          {
+            writeConcern: { w: 1 },
+            ordered: true
+          },
+          function(insertErr, insertResults) {
+            expect(insertErr).to.be.null;
+            expect(insertResults.result.n).to.equal(3);
 
-              // Execute find
-              var cursor = _server.cursor(f('%s.inserts10', self.configuration.db), {
-                aggregate: 'inserts10',
-                pipeline: [{ $match: {} }],
-                cursor: { batchSize: 1 }
-              });
+            // Execute find
+            var cursor = _server.cursor(f('%s.inserts10', self.configuration.db), {
+              aggregate: 'inserts10',
+              pipeline: [{ $match: {} }],
+              cursor: { batchSize: 1 }
+            });
+
+            // Execute next
+            cursor.next(function(cursorErr, cursorD) {
+              expect(cursorErr).to.be.null;
+              expect(cursorD.a).to.equal(1);
 
               // Execute next
-              cursor.next(function(cursorErr, cursorD) {
-                expect(cursorErr).to.be.null;
-                expect(cursorD.a).to.equal(1);
+              cursor.next(function(secondCursorErr, secondCursorD) {
+                expect(secondCursorErr).to.be.null;
+                expect(secondCursorD.a).to.equal(2);
 
-                // Execute next
-                cursor.next(function(secondCursorErr, secondCursorD) {
-                  expect(secondCursorErr).to.be.null;
-                  expect(secondCursorD.a).to.equal(2);
+                cursor.next(function(thirdCursorErr, thirdCursorD) {
+                  expect(thirdCursorErr).to.be.null;
+                  expect(thirdCursorD.a).to.equal(3);
 
-                  cursor.next(function(thirdCursorErr, thirdCursorD) {
-                    expect(thirdCursorErr).to.be.null;
-                    expect(thirdCursorD.a).to.equal(3);
-
-                    // Destroy the server connection
-                    _server.destroy();
-                    // Finish the test
-                    done();
-                  });
+                  // Destroy the server connection
+                  _server.destroy();
+                  // Finish the test
+                  done();
                 });
               });
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+            });
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -373,67 +367,67 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
 
-      self.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the write
-          _server.insert(
-            f('%s.inserts11', self.configuration.db),
-            [{ a: 1 }, { a: 2 }, { a: 3 }],
-            {
-              writeConcern: { w: 1 },
-              ordered: true
-            },
-            function(insertErr, insertResults) {
-              expect(insertErr).to.be.null;
-              expect(insertResults.result.n).to.equal(3);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Execute the write
+        _server.insert(
+          f('%s.inserts11', self.configuration.db),
+          [{ a: 1 }, { a: 2 }, { a: 3 }],
+          {
+            writeConcern: { w: 1 },
+            ordered: true
+          },
+          function(insertErr, insertResults) {
+            expect(insertErr).to.be.null;
+            expect(insertResults.result.n).to.equal(3);
 
-              // Execute the command
-              _server.command(
-                f('%s.$cmd', self.configuration.db),
-                { parallelCollectionScan: 'inserts11', numCursors: 1 },
-                function(cmdErr, cmdRes) {
-                  expect(cmdErr).to.be.null;
-                  expect(cmdRes).to.not.be.null;
+            // Execute the command
+            _server.command(
+              f('%s.$cmd', self.configuration.db),
+              { parallelCollectionScan: 'inserts11', numCursors: 1 },
+              function(cmdErr, cmdRes) {
+                expect(cmdErr).to.be.null;
+                expect(cmdRes).to.not.be.null;
 
-                  // Create cursor from parallel collection scan cursor id
-                  var cursor = _server.cursor(
-                    f('%s.inserts11', self.configuration.db),
-                    cmdRes.result.cursors[0].cursor.id,
-                    { documents: cmdRes.result.cursors[0].cursor.firstBatch }
-                  );
+                // Create cursor from parallel collection scan cursor id
+                var cursor = _server.cursor(
+                  f('%s.inserts11', self.configuration.db),
+                  cmdRes.result.cursors[0].cursor.id,
+                  { documents: cmdRes.result.cursors[0].cursor.firstBatch }
+                );
+
+                // Execute next
+                cursor.next(function(cursorErr, cursorD) {
+                  expect(cursorErr).to.be.null;
+                  expect(cursorD.a).to.equal(1);
 
                   // Execute next
-                  cursor.next(function(cursorErr, cursorD) {
-                    expect(cursorErr).to.be.null;
-                    expect(cursorD.a).to.equal(1);
+                  cursor.next(function(secondCursorErr, secondCursorD) {
+                    expect(secondCursorErr).to.be.null;
+                    expect(secondCursorD.a).to.equal(2);
 
-                    // Execute next
-                    cursor.next(function(secondCursorErr, secondCursorD) {
-                      expect(secondCursorErr).to.be.null;
-                      expect(secondCursorD.a).to.equal(2);
+                    cursor.next(function(thirdCursorErr, thirdCursorD) {
+                      expect(thirdCursorErr).to.be.null;
+                      expect(thirdCursorD.a).to.equal(3);
 
-                      cursor.next(function(thirdCursorErr, thirdCursorD) {
-                        expect(thirdCursorErr).to.be.null;
-                        expect(thirdCursorD.a).to.equal(3);
-
-                        // Destroy the server connection
-                        _server.destroy();
-                        // Finish the test
-                        done();
-                      });
+                      // Destroy the server connection
+                      _server.destroy();
+                      // Finish the test
+                      done();
                     });
                   });
-                }
-              );
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+                });
+              }
+            );
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -447,53 +441,53 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
 
-      self.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the write
-          _server.insert(
-            f('%s.inserts20', self.configuration.db),
-            [{ a: 1 }, { a: 2 }, { a: 3 }],
-            {
-              writeConcern: { w: 1 },
-              ordered: true
-            },
-            function(insertErr, insertResults) {
-              expect(insertErr).to.be.null;
-              expect(insertResults.result.n).to.equal(3);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Execute the write
+        _server.insert(
+          f('%s.inserts20', self.configuration.db),
+          [{ a: 1 }, { a: 2 }, { a: 3 }],
+          {
+            writeConcern: { w: 1 },
+            ordered: true
+          },
+          function(insertErr, insertResults) {
+            expect(insertErr).to.be.null;
+            expect(insertResults.result.n).to.equal(3);
 
-              // Execute find
-              var cursor = _server.cursor(f('%s.inserts20', self.configuration.db), {
-                aggregate: 'inserts20',
-                pipeline: [{ $match: {} }],
-                cursor: { batchSize: 1 }
-              });
+            // Execute find
+            var cursor = _server.cursor(f('%s.inserts20', self.configuration.db), {
+              aggregate: 'inserts20',
+              pipeline: [{ $match: {} }],
+              cursor: { batchSize: 1 }
+            });
 
-              // Execute next
-              cursor.next(function(cursorErr, cursorD) {
-                expect(cursorErr).to.be.null;
-                expect(cursorD.a).to.equal(1);
+            // Execute next
+            cursor.next(function(cursorErr, cursorD) {
+              expect(cursorErr).to.be.null;
+              expect(cursorD.a).to.equal(1);
 
-                // Kill the cursor
-                cursor.kill(function() {
-                  cursor.next(function(secondCursorErr, secondCursorD) {
-                    expect(secondCursorErr).to.not.exist;
-                    expect(secondCursorD).to.not.exist;
-                    // Destroy the server connection
-                    _server.destroy();
-                    // Finish the test
-                    done();
-                  });
+              // Kill the cursor
+              cursor.kill(function() {
+                cursor.next(function(secondCursorErr, secondCursorD) {
+                  expect(secondCursorErr).to.not.exist;
+                  expect(secondCursorD).to.not.exist;
+                  // Destroy the server connection
+                  _server.destroy();
+                  // Finish the test
+                  done();
                 });
               });
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+            });
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -506,53 +500,53 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
 
-      self.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Execute the write
-          _server.insert(
-            f('%s.inserts21', self.configuration.db),
-            [{ a: 1 }, { a: 2 }, { a: 3 }],
-            {
-              writeConcern: { w: 1 },
-              ordered: true
-            },
-            function(insertErr, insertResults) {
-              expect(insertErr).to.be.null;
-              expect(insertResults.result.n).to.equal(3);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Execute the write
+        _server.insert(
+          f('%s.inserts21', self.configuration.db),
+          [{ a: 1 }, { a: 2 }, { a: 3 }],
+          {
+            writeConcern: { w: 1 },
+            ordered: true
+          },
+          function(insertErr, insertResults) {
+            expect(insertErr).to.be.null;
+            expect(insertResults.result.n).to.equal(3);
 
-              // Execute find
-              var cursor = _server.cursor(f('%s.inserts21', self.configuration.db), {
-                find: f('%s.inserts21', self.configuration.db),
-                query: {},
-                batchSize: 1
-              });
+            // Execute find
+            var cursor = _server.cursor(f('%s.inserts21', self.configuration.db), {
+              find: f('%s.inserts21', self.configuration.db),
+              query: {},
+              batchSize: 1
+            });
 
-              // Execute next
-              cursor.next(function(cursorErr, cursorD) {
-                expect(cursorErr).to.be.null;
-                expect(cursorD.a).to.equal(1);
+            // Execute next
+            cursor.next(function(cursorErr, cursorD) {
+              expect(cursorErr).to.be.null;
+              expect(cursorD.a).to.equal(1);
 
-                // Kill the cursor
-                cursor.kill(function() {
-                  cursor.next(function(secondCursorErr, secondCursorD) {
-                    expect(secondCursorErr).to.not.exist;
-                    expect(secondCursorD).to.not.exist;
-                    // Destroy the server connection
-                    _server.destroy();
-                    // Finish the test
-                    done();
-                  });
+              // Kill the cursor
+              cursor.kill(function() {
+                cursor.next(function(secondCursorErr, secondCursorD) {
+                  expect(secondCursorErr).to.not.exist;
+                  expect(secondCursorD).to.not.exist;
+                  // Destroy the server connection
+                  _server.destroy();
+                  // Finish the test
+                  done();
                 });
               });
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+            });
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -563,61 +557,59 @@ describe('Operation tests', function() {
 
     test: function(done) {
       var self = this;
-      self.configuration.newTopology(function(err, server) {
-        // console.log('================ -- 1')
-        // Add event listeners
-        server.on('connect', function(_server) {
-          var left = 100;
+      const config = this.configuration;
+      const server = config.newTopology();
 
-          var insertOps = function(insertErr, insertResults) {
-            left = left - 1;
-            expect(insertErr).to.be.null;
-            expect(insertResults.result.n).to.equal(1);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        var left = 100;
 
-            // Number of operations left
-            if (left === 0) {
-              self.configuration.newTopology(function(topologyErr, innerServer) {
-                // Add event listeners
-                innerServer.on('connect', function(_innerServer) {
-                  _innerServer.command(
-                    f('%s.$cmd', self.configuration.db),
-                    { count: 'inserts_unref' },
-                    function(e, result) {
-                      expect(e).to.be.null;
-                      expect(result.result.n).to.equal(100);
+        var insertOps = function(insertErr, insertResults) {
+          left = left - 1;
+          expect(insertErr).to.be.null;
+          expect(insertResults.result.n).to.equal(1);
 
-                      _innerServer.destroy();
-                      done();
-                    }
-                  );
-                });
+          // Number of operations left
+          if (left === 0) {
+            const innerServer = config.newTopology();
+            innerServer.on('connect', function(_innerServer) {
+              _innerServer.command(
+                f('%s.$cmd', self.configuration.db),
+                { count: 'inserts_unref' },
+                function(e, result) {
+                  expect(e).to.be.null;
+                  expect(result.result.n).to.equal(100);
 
-                innerServer.connect();
-              });
-            }
-          };
+                  _innerServer.destroy();
+                  done();
+                }
+              );
+            });
 
-          for (var i = 0; i < 100; i++) {
-            // console.log('================ insert doc')
-            // Execute the write
-            _server.insert(
-              f('%s.inserts_unref', self.configuration.db),
-              [{ a: i }],
-              {
-                writeConcern: { w: 1 },
-                ordered: true
-              },
-              insertOps
-            );
-
-            // Unref all sockets
-            if (i === 10) _server.unref();
+            innerServer.connect();
           }
-        });
+        };
 
-        // Start connection
-        server.connect();
+        for (var i = 0; i < 100; i++) {
+          // console.log('================ insert doc')
+          // Execute the write
+          _server.insert(
+            f('%s.inserts_unref', self.configuration.db),
+            [{ a: i }],
+            {
+              writeConcern: { w: 1 },
+              ordered: true
+            },
+            insertOps
+          );
+
+          // Unref all sockets
+          if (i === 10) _server.unref();
+        }
       });
+
+      // Start connection
+      server.connect();
     }
   });
 });

--- a/test/tests/functional/replset_server_selection_tests.js
+++ b/test/tests/functional/replset_server_selection_tests.js
@@ -5,14 +5,14 @@ var expect = require('chai').expect,
   fs = require('fs'),
   ReplSetState = require('../../../lib/topologies/replset_state'),
   MongoError = require('../../../lib/error').MongoError,
-  ReadPreference = require('../../../lib/topologies/read_preference'),
-  Server = require('../../../lib/topologies/server');
+  ReadPreference = require('../../../lib/topologies/read_preference');
 
 describe('A replicaset with no primary', function() {
   it('should correctly execute server selection tests', {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
+      const config = this.configuration;
       var path = f(
         '%s/../spec/server-selection/server_selection/ReplicaSetNoPrimary/read',
         __dirname
@@ -23,7 +23,7 @@ describe('A replicaset with no primary', function() {
 
       // Execute each of the entries
       entries.forEach(function(x) {
-        executeEntry(x, f('%s/%s', path, x));
+        executeEntry(config, x, f('%s/%s', path, x));
       });
 
       done();
@@ -36,6 +36,7 @@ describe('A replicaset with a primary', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
+      const config = this.configuration;
       var path = f(
         '%s/../spec/server-selection/server_selection/ReplicaSetWithPrimary/read',
         __dirname
@@ -46,7 +47,7 @@ describe('A replicaset with a primary', function() {
 
       // Execute each of the entries
       entries.forEach(function(x) {
-        executeEntry(x, f('%s/%s', path, x));
+        executeEntry(config, x, f('%s/%s', path, x));
       });
 
       done();
@@ -60,7 +61,7 @@ function convert(mode) {
   return mode.toLowerCase();
 }
 
-function executeEntry(file, path) {
+function executeEntry(config, file, path) {
   // Read and parse the json file
   file = require(path);
 
@@ -75,7 +76,7 @@ function executeEntry(file, path) {
     replset.topologyType = topologyDescription.type;
     // For each server add them to the state
     topologyDescription.servers.forEach(function(s) {
-      var server = new Server({
+      var server = config.newTopology({
         host: s.address.split(':')[0],
         port: parseInt(s.address.split(':')[1], 10)
       });

--- a/test/tests/functional/sdam_monitoring_mocks/single_topology_tests.js
+++ b/test/tests/functional/sdam_monitoring_mocks/single_topology_tests.js
@@ -15,7 +15,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.mongo.Server;
+      const config = this.configuration;
 
       // Contain mock server
       var server = null;
@@ -49,7 +49,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
       });
 
       // Attempt to connect
-      server = new Server(
+      server = config.newTopology(
         Object.assign({}, mockServer.address(), {
           connectionTimeout: 3000,
           socketTimeout: 1000,
@@ -161,7 +161,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
     metadata: { requires: { generators: true, topology: 'single' } },
 
     test: function(done) {
-      var Server = this.configuration.mongo.Server;
+      const config = this.configuration;
 
       // Contain mock server
       var server = null;
@@ -196,7 +196,7 @@ describe.skip('Single SDAM Monitoring (mocks)', function() {
       });
 
       // Attempt to connect
-      server = new Server(
+      server = config.newTopology(
         Object.assign({}, mockServer.address(), {
           connectionTimeout: 3000,
           socketTimeout: 1000,

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -3,7 +3,6 @@ const expect = require('chai').expect;
 const f = require('util').format;
 const locateAuthMethod = require('./shared').locateAuthMethod;
 const executeCommand = require('./shared').executeCommand;
-const Server = require('../../../lib/topologies/server');
 const Bson = require('bson');
 const Connection = require('../../../lib/connection/connection');
 const mock = require('mongodb-mock-server');
@@ -15,8 +14,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -37,8 +36,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -65,8 +64,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -100,8 +99,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -137,11 +136,10 @@ describe('Server tests', function() {
       metadata: { requires: { topology: 'single' } },
 
       test: function(done) {
-        var Server = this.configuration.mongo.Server,
-          ReadPreference = this.configuration.mongo.ReadPreference;
+        var ReadPreference = this.configuration.mongo.ReadPreference;
 
-        // Attempt to connect
-        var server = new Server({
+        const config = this.configuration;
+        var server = config.newTopology({
           host: this.configuration.host,
           port: this.configuration.port,
           bson: new Bson(),
@@ -177,8 +175,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -217,8 +215,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -257,8 +255,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -298,8 +296,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -345,8 +343,8 @@ describe('Server tests', function() {
       var self = this;
       var testDone = false;
 
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson()
@@ -433,11 +431,9 @@ describe('Server tests', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.mongo.Server,
-        ReadPreference = this.configuration.mongo.ReadPreference;
-
-      // Attempt to connect
-      var server = new Server({
+      var ReadPreference = this.configuration.mongo.ReadPreference;
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: true,
@@ -510,11 +506,9 @@ describe('Server tests', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.require.Server,
-        ReadPreference = this.configuration.require.ReadPreference;
-
-      // Attempt to connect
-      var server = new Server({
+      var ReadPreference = this.configuration.require.ReadPreference;
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: false,
@@ -581,13 +575,12 @@ describe('Server tests', function() {
 
     test: function(done) {
       var self = this;
-
-      var Server = this.configuration.require.Server,
-        manager = this.configuration.manager;
+      const config = this.configuration;
+      var manager = this.configuration.manager;
 
       manager.stop('SIGINT').then(function() {
         // Attempt to connect while server is down
-        var server = new Server({
+        var server = config.newTopology({
           host: self.configuration.host,
           port: self.configuration.port,
           reconnect: true,
@@ -626,11 +619,10 @@ describe('Server tests', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.require.Server,
-        ReadPreference = this.configuration.require.ReadPreference;
+      var ReadPreference = this.configuration.require.ReadPreference;
 
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: true,
@@ -699,11 +691,8 @@ describe('Server tests', function() {
 
     test: function(done) {
       var self = this;
-
-      var Server = this.configuration.require.Server;
-
-      // Attempt to connect while server is down
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         reconnect: true,
@@ -756,8 +745,8 @@ describe('Server tests', function() {
 
     // The actual test we wish to run
     test: function(done) {
-      // Attempt to connect
-      var server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
         size: 10,
@@ -826,9 +815,10 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
+      const config = this.configuration;
+
       try {
-        new Server({
+        config.newTopology({
           host: this.configuration.host,
           port: this.configuration.port,
           bson: new Bson(),
@@ -849,6 +839,7 @@ describe('Server tests', function() {
 
       test: function(done) {
         var self = this;
+        const config = this.configuration;
 
         Connection.enableConnectionAccounting();
 
@@ -877,7 +868,7 @@ describe('Server tests', function() {
                 expect(cmdErr).to.not.exist;
                 expect(r).to.exist;
 
-                var server = new Server({
+                var server = config.newTopology({
                   host: self.configuration.host,
                   port: self.configuration.port,
                   bson: new Bson(),
@@ -926,6 +917,7 @@ describe('Server tests', function() {
 
       test: function(done) {
         var self = this;
+        const config = this.configuration;
 
         Connection.enableConnectionAccounting();
 
@@ -954,7 +946,7 @@ describe('Server tests', function() {
                 expect(cmdErr).to.not.exist;
                 expect(r).to.exist;
 
-                var server = new Server({
+                var server = config.newTopology({
                   host: self.configuration.host,
                   port: self.configuration.port,
                   bson: new Bson(),
@@ -983,8 +975,8 @@ describe('Server tests', function() {
       metadata: { requires: { topology: ['single'], mongodb: '>=3.5.x' } },
 
       test: function(done) {
-        // Attempt to connect to server
-        var server = new Server({
+        const config = this.configuration;
+        var server = config.newTopology({
           host: this.configuration.host,
           port: this.configuration.port,
           bson: new Bson(),
@@ -1036,7 +1028,8 @@ describe('Server tests', function() {
           request.reply(Object.assign({}, mock.DEFAULT_ISMASTER, { maxWireVersion: 1 }));
         });
 
-        const client = new Server(server.address());
+        const config = this.configuration;
+        var client = config.newTopology(server.address());
         client.on('error', error => {
           let err;
           try {
@@ -1047,9 +1040,11 @@ describe('Server tests', function() {
           }
           done(err);
         });
+
         client.on('connect', () => {
           done(new Error('This should not connect'));
         });
+
         client.connect();
       }
     });
@@ -1059,8 +1054,8 @@ describe('Server tests', function() {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
-      // Attempt to connect
-      let server = new Server({
+      const config = this.configuration;
+      var server = config.newTopology({
         host: 'doesntexist',
         bson: new Bson(),
         reconnectTries: 0

--- a/test/tests/functional/single_mocks/compression_tests.js
+++ b/test/tests/functional/single_mocks/compression_tests.js
@@ -1,8 +1,7 @@
 'use strict';
-var Server = require('../../../../lib/topologies/server'),
-  expect = require('chai').expect,
-  co = require('co'),
-  mock = require('mongodb-mock-server');
+const expect = require('chai').expect;
+const co = require('co');
+const mock = require('mongodb-mock-server');
 
 describe('Single Compression (mocks)', function() {
   afterEach(() => mock.cleanup());
@@ -18,6 +17,7 @@ describe('Single Compression (mocks)', function() {
     test: function(done) {
       // Prepare the server's response
       var serverResponse = Object.assign({}, mock.DEFAULT_ISMASTER);
+      const config = this.configuration;
 
       // Boot the mock
       co(function*() {
@@ -28,8 +28,7 @@ describe('Single Compression (mocks)', function() {
           request.reply(serverResponse);
         });
 
-        // Attempt to connect
-        var client = new Server(
+        const client = config.newTopology(
           Object.assign({}, server.address(), {
             connectionTimeout: 5000,
             socketTimeout: 1000,
@@ -59,6 +58,7 @@ describe('Single Compression (mocks)', function() {
       },
 
       test: function(done) {
+        const config = this.configuration;
         var currentStep = 0;
 
         // Prepare the server's response
@@ -95,7 +95,7 @@ describe('Single Compression (mocks)', function() {
           });
 
           // Attempt to connect
-          var client = new Server(
+          var client = config.newTopology(
             Object.assign({}, server.address(), {
               connectionTimeout: 5000,
               socketTimeout: 1000,
@@ -152,6 +152,7 @@ describe('Single Compression (mocks)', function() {
       },
 
       test: function(done) {
+        const config = this.configuration;
         var currentStep = 0;
 
         // Prepare the server's response
@@ -188,8 +189,7 @@ describe('Single Compression (mocks)', function() {
             currentStep++;
           });
 
-          // Attempt to connect
-          var client = new Server(
+          var client = config.newTopology(
             Object.assign({}, server.address(), {
               connectionTimeout: 5000,
               socketTimeout: 1000,
@@ -246,7 +246,7 @@ describe('Single Compression (mocks)', function() {
       },
 
       test: function(done) {
-        // Contain mock server
+        const config = this.configuration;
         var server = null;
         var currentStep = 0;
 
@@ -285,7 +285,7 @@ describe('Single Compression (mocks)', function() {
           });
 
           // Attempt to connect
-          var client = new Server(
+          var client = config.newTopology(
             Object.assign({}, server.address(), {
               connectionTimeout: 5000,
               socketTimeout: 1000,
@@ -340,7 +340,7 @@ describe('Single Compression (mocks)', function() {
     },
 
     test: function(done) {
-      // Contain mock server
+      const config = this.configuration;
       var server = null;
       var currentStep = 0;
 
@@ -371,8 +371,7 @@ describe('Single Compression (mocks)', function() {
           currentStep++;
         });
 
-        // Attempt to connect
-        var client = new Server(
+        var client = config.newTopology(
           Object.assign({}, server.address(), {
             connectionTimeout: 5000,
             socketTimeout: 1000,

--- a/test/tests/functional/single_mocks/timeout_tests.js
+++ b/test/tests/functional/single_mocks/timeout_tests.js
@@ -15,7 +15,7 @@ describe('Single Timeout (mocks)', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.mongo.Server;
+      const config = this.configuration;
 
       // Current index for the ismaster
       var currentStep = 0;
@@ -58,8 +58,7 @@ describe('Single Timeout (mocks)', function() {
           stopRespondingPrimary = true;
         }, 5000);
 
-        // Attempt to connect
-        var replset = new Server(
+        var replset = config.newTopology(
           Object.assign({}, server.address(), {
             connectionTimeout: 5000,
             socketTimeout: 1000,
@@ -110,7 +109,7 @@ describe('Single Timeout (mocks)', function() {
     },
 
     test: function(done) {
-      var Server = this.configuration.mongo.Server;
+      const config = this.configuration;
 
       // Current index for the ismaster
       var currentStep = 0;
@@ -153,8 +152,7 @@ describe('Single Timeout (mocks)', function() {
           }
         });
 
-        // Attempt to connect
-        const server = new Server(
+        var server = config.newTopology(
           Object.assign({}, mockServer.address(), {
             connectionTimeout: 3000,
             socketTimeout: 2000,
@@ -265,7 +263,7 @@ describe('Single Timeout (mocks)', function() {
       },
 
       test: function(done) {
-        var Server = this.configuration.mongo.Server;
+        const config = this.configuration;
 
         // Current index for the ismaster
         var currentStep = 0;
@@ -294,8 +292,7 @@ describe('Single Timeout (mocks)', function() {
             }
           });
 
-          // Attempt to connect
-          const server = new Server(
+          var server = config.newTopology(
             Object.assign({}, mockServer.address(), {
               connectionTimeout: 2000,
               socketTimeout: 1000,

--- a/test/tests/functional/tailable_cursor_tests.js
+++ b/test/tests/functional/tailable_cursor_tests.js
@@ -11,70 +11,70 @@ describe('Tailable cursor tests', function() {
 
     test: function(done) {
       var self = this;
+      const config = this.configuration;
+      const server = config.newTopology();
 
-      this.configuration.newTopology(function(err, server) {
-        var ns = f('%s.cursor_tailable', self.configuration.db);
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Create a capped collection
-          _server.command(
-            f('%s.$cmd', self.configuration.db),
-            { create: 'cursor_tailable', capped: true, size: 10000 },
-            function(cmdErr, cmdRes) {
-              expect(cmdErr).to.not.exist;
-              expect(cmdRes).to.exist;
+      var ns = f('%s.cursor_tailable', self.configuration.db);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Create a capped collection
+        _server.command(
+          f('%s.$cmd', self.configuration.db),
+          { create: 'cursor_tailable', capped: true, size: 10000 },
+          function(cmdErr, cmdRes) {
+            expect(cmdErr).to.not.exist;
+            expect(cmdRes).to.exist;
 
-              // Execute the write
-              _server.insert(
-                ns,
-                [{ a: 1 }],
-                {
-                  writeConcern: { w: 1 },
-                  ordered: true
-                },
-                function(insertErr, results) {
-                  expect(insertErr).to.be.null;
-                  expect(results.result.n).to.equal(1);
+            // Execute the write
+            _server.insert(
+              ns,
+              [{ a: 1 }],
+              {
+                writeConcern: { w: 1 },
+                ordered: true
+              },
+              function(insertErr, results) {
+                expect(insertErr).to.be.null;
+                expect(results.result.n).to.equal(1);
 
-                  // Execute find
-                  var cursor = _server.cursor(ns, {
-                    find: ns,
-                    query: {},
-                    batchSize: 2,
-                    tailable: true,
-                    awaitData: true
+                // Execute find
+                var cursor = _server.cursor(ns, {
+                  find: ns,
+                  query: {},
+                  batchSize: 2,
+                  tailable: true,
+                  awaitData: true
+                });
+
+                // Execute next
+                cursor.next(function(cursorErr, cursorD) {
+                  expect(cursorErr).to.be.null;
+                  expect(cursorD).to.exist;
+
+                  var s = new Date();
+
+                  cursor.next(function() {
+                    var e = new Date();
+                    expect(e.getTime() - s.getTime()).to.be.at.least(300);
+
+                    // Destroy the server connection
+                    _server.destroy();
+                    // Finish the test
+                    done();
                   });
 
-                  // Execute next
-                  cursor.next(function(cursorErr, cursorD) {
-                    expect(cursorErr).to.be.null;
-                    expect(cursorD).to.exist;
-
-                    var s = new Date();
-
-                    cursor.next(function() {
-                      var e = new Date();
-                      expect(e.getTime() - s.getTime()).to.be.at.least(300);
-
-                      // Destroy the server connection
-                      _server.destroy();
-                      // Finish the test
-                      done();
-                    });
-
-                    setTimeout(function() {
-                      cursor.kill();
-                    }, 300);
-                  });
-                }
-              );
-            }
-          );
-        });
-
-        // Start connection
-        server.connect();
+                  setTimeout(function() {
+                    cursor.kill();
+                  }, 300);
+                });
+              }
+            );
+          }
+        );
       });
+
+      // Start connection
+      server.connect();
     }
   });
 });

--- a/test/tests/functional/undefined_tests.js
+++ b/test/tests/functional/undefined_tests.js
@@ -12,51 +12,52 @@ describe('A server', function() {
 
     test: function(done) {
       var self = this;
-      this.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Drop collection
-          _server.command(f('%s.$cmd', self.configuration.db), { drop: 'insert1' }, function() {
-            var ns = f('%s.insert1', self.configuration.db);
-            var objectId = new ObjectId();
-            // Execute the write
-            _server.insert(
-              ns,
-              [{ _id: objectId, a: 1, b: undefined }],
-              {
-                writeConcern: { w: 1 },
-                ordered: true,
-                ignoreUndefined: true
-              },
-              function(insertErr, results) {
-                expect(insertErr).to.be.null;
-                expect(results.result.n).to.eql(1);
+      const config = this.configuration;
+      const server = config.newTopology();
 
-                // Execute find
-                var cursor = _server.cursor(ns, {
-                  find: f('%s.insert1', self.configuration.db),
-                  query: { _id: objectId },
-                  batchSize: 2
-                });
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Drop collection
+        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'insert1' }, function() {
+          var ns = f('%s.insert1', self.configuration.db);
+          var objectId = new ObjectId();
+          // Execute the write
+          _server.insert(
+            ns,
+            [{ _id: objectId, a: 1, b: undefined }],
+            {
+              writeConcern: { w: 1 },
+              ordered: true,
+              ignoreUndefined: true
+            },
+            function(insertErr, results) {
+              expect(insertErr).to.be.null;
+              expect(results.result.n).to.eql(1);
 
-                // Execute next
-                cursor.next(function(nextErr, d) {
-                  expect(nextErr).to.be.null;
-                  expect(d.b).to.be.undefined;
+              // Execute find
+              var cursor = _server.cursor(ns, {
+                find: f('%s.insert1', self.configuration.db),
+                query: { _id: objectId },
+                batchSize: 2
+              });
 
-                  // Destroy the connection
-                  _server.destroy();
-                  // Finish the test
-                  done();
-                });
-              }
-            );
-          });
+              // Execute next
+              cursor.next(function(nextErr, d) {
+                expect(nextErr).to.be.null;
+                expect(d.b).to.be.undefined;
+
+                // Destroy the connection
+                _server.destroy();
+                // Finish the test
+                done();
+              });
+            }
+          );
         });
-
-        // Start connection
-        server.connect();
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -67,55 +68,56 @@ describe('A server', function() {
 
     test: function(done) {
       var self = this;
-      this.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          // Drop collection
-          _server.command(f('%s.$cmd', self.configuration.db), { drop: 'update1' }, function() {
-            var ns = f('%s.update1', self.configuration.db);
-            var objectId = new ObjectId();
-            // Execute the write
-            _server.update(
-              ns,
-              {
-                q: { _id: objectId, a: 1, b: undefined },
-                u: { $set: { a: 1, b: undefined } },
-                upsert: true
-              },
-              {
-                writeConcern: { w: 1 },
-                ordered: true,
-                ignoreUndefined: true
-              },
-              function(insertErr, results) {
-                expect(insertErr).to.be.null;
-                expect(results.result.n).to.eql(1);
+      const config = this.configuration;
+      const server = config.newTopology();
 
-                // Execute find
-                var cursor = _server.cursor(ns, {
-                  find: f('%s.update1', self.configuration.db),
-                  query: { _id: objectId },
-                  batchSize: 2
-                });
+      // Add event listeners
+      server.on('connect', function(_server) {
+        // Drop collection
+        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'update1' }, function() {
+          var ns = f('%s.update1', self.configuration.db);
+          var objectId = new ObjectId();
+          // Execute the write
+          _server.update(
+            ns,
+            {
+              q: { _id: objectId, a: 1, b: undefined },
+              u: { $set: { a: 1, b: undefined } },
+              upsert: true
+            },
+            {
+              writeConcern: { w: 1 },
+              ordered: true,
+              ignoreUndefined: true
+            },
+            function(insertErr, results) {
+              expect(insertErr).to.be.null;
+              expect(results.result.n).to.eql(1);
 
-                // Execute next
-                cursor.next(function(nextErr, d) {
-                  expect(nextErr).to.be.null;
-                  expect(d.b).to.be.undefined;
+              // Execute find
+              var cursor = _server.cursor(ns, {
+                find: f('%s.update1', self.configuration.db),
+                query: { _id: objectId },
+                batchSize: 2
+              });
 
-                  // Destroy the connection
-                  _server.destroy();
-                  // Finish the test
-                  done();
-                });
-              }
-            );
-          });
+              // Execute next
+              cursor.next(function(nextErr, d) {
+                expect(nextErr).to.be.null;
+                expect(d.b).to.be.undefined;
+
+                // Destroy the connection
+                _server.destroy();
+                // Finish the test
+                done();
+              });
+            }
+          );
         });
-
-        // Start connection
-        server.connect();
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -126,57 +128,58 @@ describe('A server', function() {
 
     test: function(done) {
       var self = this;
-      this.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          var ns = f('%s.remove1', self.configuration.db);
-          var objectId = new ObjectId();
+      const config = this.configuration;
+      const server = config.newTopology();
 
-          _server.command(f('%s.$cmd', self.configuration.db), { drop: 'remove1' }, function() {
-            // Execute the write
-            _server.insert(
-              ns,
-              [{ id: objectId, a: 1, b: undefined }, { id: objectId, a: 2, b: 1 }],
-              {
-                writeConcern: { w: 1 },
-                ordered: true
-              },
-              function(insertErr, results) {
-                expect(insertErr).to.be.null;
-                expect(results.result.n).to.eql(2);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        var ns = f('%s.remove1', self.configuration.db);
+        var objectId = new ObjectId();
 
-                // Execute the write
-                _server.remove(
-                  ns,
-                  [
-                    {
-                      q: { b: undefined },
-                      limit: 0
-                    }
-                  ],
+        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'remove1' }, function() {
+          // Execute the write
+          _server.insert(
+            ns,
+            [{ id: objectId, a: 1, b: undefined }, { id: objectId, a: 2, b: 1 }],
+            {
+              writeConcern: { w: 1 },
+              ordered: true
+            },
+            function(insertErr, results) {
+              expect(insertErr).to.be.null;
+              expect(results.result.n).to.eql(2);
+
+              // Execute the write
+              _server.remove(
+                ns,
+                [
                   {
-                    writeConcern: { w: 1 },
-                    ordered: true,
-                    ignoreUndefined: true
-                  },
-                  function(removeErr, removeResults) {
-                    expect(removeErr).to.be.null;
-                    expect(removeResults.result.n).to.eql(2);
-
-                    // Destroy the connection
-                    _server.destroy();
-                    // Finish the test
-                    done();
+                    q: { b: undefined },
+                    limit: 0
                   }
-                );
-              }
-            );
-          });
-        });
+                ],
+                {
+                  writeConcern: { w: 1 },
+                  ordered: true,
+                  ignoreUndefined: true
+                },
+                function(removeErr, removeResults) {
+                  expect(removeErr).to.be.null;
+                  expect(removeResults.result.n).to.eql(2);
 
-        // Start connection
-        server.connect();
+                  // Destroy the connection
+                  _server.destroy();
+                  // Finish the test
+                  done();
+                }
+              );
+            }
+          );
+        });
       });
+
+      // Start connection
+      server.connect();
     }
   });
 
@@ -187,56 +190,57 @@ describe('A server', function() {
 
     test: function(done) {
       var self = this;
-      this.configuration.newTopology(function(err, server) {
-        // Add event listeners
-        server.on('connect', function(_server) {
-          var ns = f('%s.remove2', self.configuration.db);
-          var objectId = new ObjectId();
+      const config = this.configuration;
+      const server = config.newTopology();
 
-          _server.command(f('%s.$cmd', self.configuration.db), { drop: 'remove2' }, function() {
-            // Execute the write
-            _server.insert(
-              ns,
-              [{ id: objectId, a: 1, b: undefined }, { id: objectId, a: 2, b: 1 }],
-              {
-                writeConcern: { w: 1 },
-                ordered: true
-              },
-              function(insertErr, results) {
-                expect(insertErr).to.be.null;
-                expect(results.result.n).to.eql(2);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        var ns = f('%s.remove2', self.configuration.db);
+        var objectId = new ObjectId();
 
-                // Execute the write
-                _server.remove(
-                  ns,
-                  [
-                    {
-                      q: { b: null },
-                      limit: 0
-                    }
-                  ],
+        _server.command(f('%s.$cmd', self.configuration.db), { drop: 'remove2' }, function() {
+          // Execute the write
+          _server.insert(
+            ns,
+            [{ id: objectId, a: 1, b: undefined }, { id: objectId, a: 2, b: 1 }],
+            {
+              writeConcern: { w: 1 },
+              ordered: true
+            },
+            function(insertErr, results) {
+              expect(insertErr).to.be.null;
+              expect(results.result.n).to.eql(2);
+
+              // Execute the write
+              _server.remove(
+                ns,
+                [
                   {
-                    writeConcern: { w: 1 },
-                    ordered: true
-                  },
-                  function(removeErr, removeResults) {
-                    expect(removeErr).to.be.null;
-                    expect(removeResults.result.n).to.eql(1);
-
-                    // Destroy the connection
-                    _server.destroy();
-                    // Finish the test
-                    done();
+                    q: { b: null },
+                    limit: 0
                   }
-                );
-              }
-            );
-          });
-        });
+                ],
+                {
+                  writeConcern: { w: 1 },
+                  ordered: true
+                },
+                function(removeErr, removeResults) {
+                  expect(removeErr).to.be.null;
+                  expect(removeResults.result.n).to.eql(1);
 
-        // Start connection
-        server.connect();
+                  // Destroy the connection
+                  _server.destroy();
+                  // Finish the test
+                  done();
+                }
+              );
+            }
+          );
+        });
       });
+
+      // Start connection
+      server.connect();
     }
   });
 });


### PR DESCRIPTION
There are a number of tests that are meant to be run against
replicasets which were using a `Server` topology. The errors were
not immediately obvious, until my primary changed from the default
port of 31000 and many `Not Master` errors started popping up.

NODE-1687