### PR TITLE
fix(mongos): solve memory leak on server reconnection

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -617,9 +617,7 @@ function reconnectProxies(self, proxies, callback) {
       removeProxyFrom(self.disconnectedProxies, _server);
 
       // Relay the server description change
-      server.on('serverDescriptionChanged', function(event) {
-        self.emit('serverDescriptionChanged', event);
-      });
+      server.on('serverDescriptionChanged', self.emit.bind(self, 'serverDescriptionChanged'));
 
       // Emit opening server event
       self.emit('serverOpening', {


### PR DESCRIPTION
**The closure of the `serverDescriptionChanged` event handler references the old _server instance, preventing old disconnected server instances from being cleaned by GC.
Has noticeable effect on memory usage after a large amount of disconnections.

Solution: bind the emit function to its parameters without declaring a function which would inherit the closure.**

Can be tested by changing the test in mongodb-core\test\tests\unit\mongos\reconnect_tests.js to take heapdumps.

Attached 2 heapdumps, with and without the fix. When opened in chrome dev-tools, the version without the fix contains a larger amount of Server instances, retained by serverDescriptionChanged event.

[heapdumps.zip](https://github.com/mongodb-js/mongodb-core/files/2435540/heapdumps.zip)
![example-mem](https://user-images.githubusercontent.com/23508468/46314299-d14ba600-c5d2-11e8-815f-8114beba8c9b.png)

