### PR TITLE
fix: Cannot read property 'greaterThan' of undefined

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -1198,6 +1198,7 @@ Pool.prototype.write = function(commands, options, cb) {
 
       if (
         operation.session.clusterTime &&
+        operation.session.clusterTime.clusterTime &&
         operation.session.clusterTime.clusterTime.greaterThan(
           sessionOptions.$clusterTime.clusterTime
         )


### PR DESCRIPTION
fixes following error:
TypeError: Cannot read property 'greaterThan' of undefined
    at Pool.write (/var/app/current/node_modules/mongodb-core/lib/connection/pool.js:1201:51)
    at WireProtocol.getMore (/var/app/current/node_modules/mongodb-core/lib/wireprotocol/3_2_support.js:344:14)
    at Cursor._getmore (/var/app/current/node_modules/mongodb-core/lib/cursor.js:349:35)
    at nextFunction (/var/app/current/node_modules/mongodb-core/lib/cursor.js:653:10)
    at Cursor.next (/var/app/current/node_modules/mongodb-core/lib/cursor.js:833:3)
    at Cursor._next (/var/app/current/node_modules/mongodb/lib/cursor.js:211:36)
    at nextObject (/var/app/current/node_modules/mongodb/lib/operations/cursor_ops.js:179:10)
    at next (/var/app/current/node_modules/mongodb/lib/operations/cursor_ops.js:158:3)
    at executeOperation (/var/app/current/node_modules/mongodb/lib/utils.js:420:24)
    at Cursor.next (/var/app/current/node_modules/mongodb/lib/cursor.js:253:10)
    at _next (/var/app/current/node_modules/mongoose/lib/cursor/QueryCursor.js:261:23)
    at /var/app/current/node_modules/mongoose/lib/cursor/QueryCursor.js:202:42
    at /var/app/current/node_modules/mongoose/lib/helpers/cursor/eachAsync.js:42:7
    at /var/app/current/node_modules/async/dist/async.js:4096:9
    at Object.process (/var/app/current/node_modules/async/dist/async.js:2344:17)
    at /var/app/current/node_modules/async/dist/async.js:2252:19
    at Immediate.<anonymous> (/var/app/current/node_modules/async/dist/async.js:119:16)
    at runCallback (timers.js:810:20)
    at tryOnImmediate (timers.js:768:5)
    at processImmediate [as _immediateCallback] (timers.js:745:5)