### PR TITLE
fix(uri_parser) bypass number coercion for replicaSet val in connection string

### DIFF
--- a/lib/uri_parser.js
+++ b/lib/uri_parser.js
@@ -175,7 +175,7 @@ const BOOLEAN_OPTIONS = new Set([
 ]);
 
 // Known string options, only used to bypass Number coercion in `parseQueryStringItemValue`
-const STRING_OPTIONS = new Set(['authsource']);
+const STRING_OPTIONS = new Set(['authsource', 'replicaset']);
 
 // Supported text representations of auth mechanisms
 // NOTE: this list exists in native already, if it is merged here we should deduplicate

--- a/test/tests/unit/connection_string_tests.js
+++ b/test/tests/unit/connection_string_tests.js
@@ -119,6 +119,16 @@ describe('Connection String', function() {
     });
   });
 
+  it('should parse a replicaSet with a leading number', function(done) {
+    parseConnectionString('mongodb://localhost/?replicaSet=123abc', (err, result) => {
+      expect(err).to.not.exist;
+      expect(result.options).to.have.property('replicaSet');
+      expect(result.options.replicaSet).to.equal('123abc');
+
+      done();
+    });
+  });
+
   describe('validation', function() {
     it('should validate compression options', function(done) {
       parseConnectionString('mongodb://localhost/?zlibCompressionLevel=15', err => {


### PR DESCRIPTION
re: Automattic/mongoose/issues/7167 ( replicaSet details and native code sample there ).

If a setName starts with a number, the new url parser will coerce the replicaSet value passed into the connection string to a number e.g. `replicaSet=456abc` becomes `456`.  Setting the value in the connection options works as expected. This change adds replicaset to the set of known strings.