### PR TITLE
NODE-1683: defensively avoid memory leaks in new SDAM layer

### DIFF
--- a/lib/sdam/monitoring.js
+++ b/lib/sdam/monitoring.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ServerDescription = require('./server_description').ServerDescription;
+const ServerType = require('./server_description').ServerType;
 const calculateDurationInMs = require('../utils').calculateDurationInMs;
 
 /**
@@ -188,6 +189,11 @@ function monitorServer(server) {
     // an ismaster call fails we reset the server's pool. If a server was once connected,
     // change its type to `Unknown` only after retrying once.
     server.s.pool.reset(() => {
+      if (server.description.type === ServerType.Unknown) {
+        return;
+      }
+
+      // otherwise re-attempt monitoring once
       checkServer((error, isMaster) => {
         if (error) {
           server.s.monitoring = false;

--- a/lib/sdam/topology.js
+++ b/lib/sdam/topology.js
@@ -33,6 +33,28 @@ const TOPOLOGY_DEFAULTS = {
   minHeartbeatIntervalMS: 500
 };
 
+// events that we relay to the `Topology`
+const SERVER_RELAY_EVENTS = [
+  'serverHeartbeatStarted',
+  'serverHeartbeatSucceeded',
+  'serverHeartbeatFailed',
+  'commandStarted',
+  'commandSucceeded',
+  'commandFailed',
+
+  // NOTE: Legacy events
+  'monitoring'
+];
+
+// all events we listen to from `Server` instances
+const LOCAL_SERVER_EVENTS = SERVER_RELAY_EVENTS.concat([
+  'error',
+  'connect',
+  'descriptionReceived',
+  'close',
+  'ended'
+]);
+
 // Collect details for client info
 const driverVersion = require('../../package.json').version;
 const nodejsversion = `Node.js ${process.version}, ${os.endianness()}`;
@@ -247,12 +269,7 @@ class Topology extends EventEmitter {
     // destroy all child servers
     let destroyed = 0;
     servers.forEach(server =>
-      server.destroy(() => {
-        this.emit(
-          'serverClosed',
-          new monitoring.ServerClosedEvent(this.s.id, server.description.address)
-        );
-
+      destroyServer(server, this, () => {
         destroyed++;
         if (destroyed === servers.size) {
           // emit an event for close
@@ -586,6 +603,24 @@ function isWriteCommand(command) {
 }
 
 /**
+ * Destroys a server, and removes all event listeners from the instance
+ *
+ * @param {Server} server
+ */
+function destroyServer(server, topology, callback) {
+  LOCAL_SERVER_EVENTS.forEach(event => server.removeAllListeners(event));
+
+  server.destroy(() => {
+    topology.emit(
+      'serverClosed',
+      new monitoring.ServerClosedEvent(topology.s.id, server.description.address)
+    );
+
+    if (typeof callback === 'function') callback(null, null);
+  });
+}
+
+/**
  * Parses a basic seedlist in string form
  *
  * @param {string} seedlist The seedlist to parse
@@ -699,17 +734,7 @@ function createAndConnectServer(topology, serverDescription) {
   );
 
   const server = new Server(serverDescription, topology.s.options);
-  relayEvents(server, topology, [
-    'serverHeartbeatStarted',
-    'serverHeartbeatSucceeded',
-    'serverHeartbeatFailed',
-    'commandStarted',
-    'commandSucceeded',
-    'commandFailed',
-
-    // NOTE: Legacy events
-    'monitoring'
-  ]);
+  relayEvents(server, topology, SERVER_RELAY_EVENTS);
 
   server.once('connect', serverConnectEventHandler(server, topology));
   server.on('descriptionReceived', topology.serverUpdateHandler.bind(topology));
@@ -759,9 +784,8 @@ function updateServers(topology, currentServerDescription) {
     const server = topology.s.servers.get(serverAddress);
     topology.s.servers.delete(serverAddress);
 
-    server.destroy(() =>
-      topology.emit('serverClosed', new monitoring.ServerClosedEvent(topology.s.id, serverAddress))
-    );
+    // prepare server for garbage collection
+    destroyServer(server, topology);
   }
 }
 

--- a/lib/sdam/topology.js
+++ b/lib/sdam/topology.js
@@ -20,7 +20,7 @@ const isRetryableError = require('../error').isRetryableError;
 const MongoParseError = require('../error').MongoParseError;
 const ClientSession = require('../sessions').ClientSession;
 const ServerType = require('./server_description').ServerType;
-const os = require('os');
+const createClientInfo = require('../topologies/shared').createClientInfo;
 
 // Global state
 let globalTopologyCounter = 0;
@@ -54,14 +54,6 @@ const LOCAL_SERVER_EVENTS = SERVER_RELAY_EVENTS.concat([
   'close',
   'ended'
 ]);
-
-// Collect details for client info
-const driverVersion = require('../../package.json').version;
-const nodejsversion = `Node.js ${process.version}, ${os.endianness()}`;
-const type = os.type();
-const name = process.platform;
-const architecture = process.arch;
-const release = os.release();
 
 /**
  * A container of server instances representing a connection to a MongoDB topology.
@@ -151,19 +143,7 @@ class Topology extends EventEmitter {
     this.s.options.compression = { compressors: createCompressionInfo(options) };
 
     // add client info
-    this.s.clientInfo = {
-      driver: {
-        name: 'nodejs',
-        version: driverVersion
-      },
-      os: {
-        type: type,
-        name: name,
-        architecture: architecture,
-        version: release
-      },
-      platform: nodejsversion
-    };
+    this.s.clientInfo = createClientInfo(options);
   }
 
   /**

--- a/lib/sdam/topology.js
+++ b/lib/sdam/topology.js
@@ -353,13 +353,11 @@ class Topology extends EventEmitter {
     const previousServerDescription = this.s.description.servers.get(serverDescription.address);
 
     // first update the TopologyDescription
-    const updatedDescription = this.s.description.update(serverDescription);
-    if (updatedDescription.compatibilityError) {
-      this.emit('error', new MongoError(updatedDescription.compatibilityError));
+    this.s.description = this.s.description.update(serverDescription);
+    if (this.s.description.compatibilityError) {
+      this.emit('error', new MongoError(this.s.description.compatibilityError));
       return;
     }
-
-    this.s.description = updatedDescription;
 
     // emit monitoring events for this change
     this.emit(

--- a/lib/sdam/topology.js
+++ b/lib/sdam/topology.js
@@ -209,6 +209,7 @@ class Topology extends EventEmitter {
       const connectHandler = (_, err) => {
         server.removeListener('error', errorHandler);
         this.emit('open', err, this);
+        this.emit('connect', this);
 
         if (typeof callback === 'function') callback(err, this);
       };

--- a/lib/sdam/topology.js
+++ b/lib/sdam/topology.js
@@ -21,6 +21,7 @@ const MongoParseError = require('../error').MongoParseError;
 const ClientSession = require('../sessions').ClientSession;
 const ServerType = require('./server_description').ServerType;
 const createClientInfo = require('../topologies/shared').createClientInfo;
+const MongoError = require('../error').MongoError;
 
 // Global state
 let globalTopologyCounter = 0;
@@ -352,7 +353,13 @@ class Topology extends EventEmitter {
     const previousServerDescription = this.s.description.servers.get(serverDescription.address);
 
     // first update the TopologyDescription
-    this.s.description = this.s.description.update(serverDescription);
+    const updatedDescription = this.s.description.update(serverDescription);
+    if (updatedDescription.compatibilityError) {
+      this.emit('error', new MongoError(updatedDescription.compatibilityError));
+      return;
+    }
+
+    this.s.description = updatedDescription;
 
     // emit monitoring events for this change
     this.emit(
@@ -846,8 +853,7 @@ function executeWriteOperation(args, options, callback) {
 }
 
 /**
- * Resets the internal state of this server to `Unknown`, and optionally schedules
- * monitoring
+ * Resets the internal state of this server to `Unknown`.
  *
  * @private
  * @param {Server} server

--- a/lib/sdam/topology_description.js
+++ b/lib/sdam/topology_description.js
@@ -49,6 +49,8 @@ class TopologyDescription {
 
     // determine server compatibility
     for (const serverDescription of this.servers.values()) {
+      if (serverDescription.type === ServerType.Unknown) continue;
+
       if (serverDescription.minWireVersion > MAX_SUPPORTED_WIRE_VERSION) {
         this.compatible = false;
         this.compatibilityError = `Server at ${serverDescription.address} requires wire version ${

--- a/test/config.js
+++ b/test/config.js
@@ -15,6 +15,10 @@ class CoreConfiguration extends ConfigurationBase {
     this.topology = options.topology || this.defaultTopology;
   }
 
+  usingUnifiedTopology() {
+    return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
+  }
+
   defaultTopology(self, _mongo, options) {
     options = Object.assign(
       {},
@@ -24,6 +28,10 @@ class CoreConfiguration extends ConfigurationBase {
       },
       options
     );
+
+    if (this.usingUnifiedTopology()) {
+      return new _mongo.Topology(options);
+    }
 
     return new _mongo.Server(options);
   }

--- a/test/environments.js
+++ b/test/environments.js
@@ -9,6 +9,10 @@ const ServerManager = topologyManagers.Server;
 const ReplSetManager = topologyManagers.ReplSet;
 const ShardingManager = topologyManagers.Sharded;
 
+function usingUnifiedTopology() {
+  return !!process.env.MONGODB_UNIFIED_TOPOLOGY;
+}
+
 class ReplicaSetEnvironment extends EnvironmentBase {
   static get displayName() {
     return 'replicaset';
@@ -21,6 +25,10 @@ class ReplicaSetEnvironment extends EnvironmentBase {
     this.port = 31000;
     this.setName = 'rs';
     this.topology = (self, _mongo) => {
+      if (usingUnifiedTopology()) {
+        return new _mongo.Topology([{ host: 'localhost', port: 31000 }], { setName: 'rs' });
+      }
+
       return new _mongo.ReplSet([{ host: 'localhost', port: 31000 }], { setName: 'rs' });
     };
 
@@ -92,6 +100,10 @@ class ShardedEnvironment extends EnvironmentBase {
     this.host = 'localhost';
     this.port = 51000;
     this.topology = (self, _mongo) => {
+      if (usingUnifiedTopology()) {
+        return new _mongo.Topology([{ host: 'localhost', port: 51000 }]);
+      }
+
       return new _mongo.Mongos([{ host: 'localhost', port: 51000 }]);
     };
 

--- a/test/tests/functional/cursor_tests.js
+++ b/test/tests/functional/cursor_tests.js
@@ -421,6 +421,13 @@ describe('Cursor tests', function() {
     },
 
     test: function(done) {
+      const configuration = this.configuration;
+      if (configuration.usingUnifiedTopology()) {
+        // This test tries to inspect the connection pool directly on the topology, which
+        // will no longer work with the new Topology type. The test should be reworked.
+        return this.skip();
+      }
+
       const server = this.configuration.newTopology();
       var ns = f('%s.cursor4', this.configuration.db);
       // Add event listeners

--- a/test/tests/functional/replset_server_selection_tests.js
+++ b/test/tests/functional/replset_server_selection_tests.js
@@ -8,6 +8,11 @@ var expect = require('chai').expect,
   ReadPreference = require('../../../lib/topologies/read_preference');
 
 describe('A replicaset with no primary', function() {
+  before(function() {
+    // These tests are not relevant to the new topology layer
+    if (this.configuration.usingUnifiedTopology()) this.skip();
+  });
+
   it('should correctly execute server selection tests', {
     metadata: { requires: { topology: 'single' } },
 
@@ -32,6 +37,11 @@ describe('A replicaset with no primary', function() {
 });
 
 describe('A replicaset with a primary', function() {
+  before(function() {
+    // These tests are not relevant to the new topology layer
+    if (this.configuration.usingUnifiedTopology()) this.skip();
+  });
+
   it('should correctly execute server selection tests', {
     metadata: { requires: { topology: 'single' } },
 

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -508,6 +508,11 @@ describe('Server tests', function() {
     test: function(done) {
       var ReadPreference = this.configuration.require.ReadPreference;
       const config = this.configuration;
+      if (config.usingUnifiedTopology()) {
+        // The new SDAM layer always reconnects, so this test is no longer relevant
+        return this.skip();
+      }
+
       var server = config.newTopology({
         host: this.configuration.host,
         port: this.configuration.port,
@@ -976,6 +981,11 @@ describe('Server tests', function() {
 
       test: function(done) {
         const config = this.configuration;
+        if (config.usingUnifiedTopology()) {
+          // Disabled for inspection of properties only relevant to legacy topology
+          return this.skip();
+        }
+
         var server = config.newTopology({
           host: this.configuration.host,
           port: this.configuration.port,
@@ -1034,7 +1044,11 @@ describe('Server tests', function() {
           let err;
           try {
             expect(error).to.be.an.instanceOf(Error);
-            expect(error.message).to.have.string('but this version of Node.js Driver requires');
+            if (config.usingUnifiedTopology()) {
+              expect(error.message).to.match(/but this version of the driver requires at least/);
+            } else {
+              expect(error.message).to.have.string('but this version of Node.js Driver requires');
+            }
           } catch (e) {
             err = e;
           }
@@ -1055,6 +1069,11 @@ describe('Server tests', function() {
 
     test: function(done) {
       const config = this.configuration;
+      if (config.usingUnifiedTopology()) {
+        // Disabled for inspection of values that assume legacy topologies
+        return this.skip();
+      }
+
       var server = config.newTopology({
         host: 'doesntexist',
         bson: new Bson(),

--- a/test/tests/functional/single_mocks/compression_tests.js
+++ b/test/tests/functional/single_mocks/compression_tests.js
@@ -77,6 +77,12 @@ describe('Single Compression (mocks)', function() {
               // Acknowledge connection using OP_COMPRESSED with no compression
               request.reply(serverResponse, { compression: { compressor: 'no_compression' } });
             } else if (currentStep === 1) {
+              if (doc.ismaster) {
+                // unified topology
+                request.reply(serverResponse, { compression: { compressor: 'no_compression' } });
+                return;
+              }
+
               expect(server.isCompressed).to.be.false;
               // Acknowledge insertion using OP_COMPRESSED with no compression
               request.reply(
@@ -172,6 +178,12 @@ describe('Single Compression (mocks)', function() {
               // Acknowledge connection using OP_COMPRESSED with snappy
               request.reply(serverResponse, { compression: { compressor: 'snappy' } });
             } else if (currentStep === 1) {
+              if (doc.ismaster) {
+                // unified topology
+                request.reply(serverResponse, { compression: { compressor: 'snappy' } });
+                return;
+              }
+
               expect(server.isCompressed).to.be.true;
               // Acknowledge insertion using OP_COMPRESSED with snappy
               request.reply(
@@ -267,6 +279,12 @@ describe('Single Compression (mocks)', function() {
               // Acknowledge connection using OP_COMPRESSED with zlib
               request.reply(serverResponse, { compression: { compressor: 'zlib' } });
             } else if (currentStep === 1) {
+              if (doc.ismaster) {
+                // unified topology
+                request.reply(serverResponse, { compression: { compressor: 'zlib' } });
+                return;
+              }
+
               expect(server.isCompressed).to.be.true;
               // Acknowledge insertion using OP_COMPRESSED with zlib
               request.reply(
@@ -354,12 +372,19 @@ describe('Single Compression (mocks)', function() {
         server = yield mock.createServer();
 
         server.setMessageHandler(request => {
+          const doc = request.document;
           if (currentStep === 0) {
             expect(request.response.documents[0].compression).to.have.members(['snappy', 'zlib']);
             expect(server.isCompressed).to.be.false;
             // Acknowledge connection using OP_COMPRESSED with snappy
             request.reply(serverResponse, { compression: { compressor: 'snappy' } });
           } else if (currentStep === 1) {
+            if (doc.ismaster) {
+              // unified topology
+              request.reply(serverResponse, { compression: { compressor: 'snappy' } });
+              return;
+            }
+
             expect(server.isCompressed).to.be.true;
             // Acknowledge ping using OP_COMPRESSED with snappy
             request.reply({ ok: 1 }, { compression: { compressor: 'snappy' } });

--- a/test/tests/functional/single_mocks/timeout_tests.js
+++ b/test/tests/functional/single_mocks/timeout_tests.js
@@ -4,6 +4,13 @@ var expect = require('chai').expect,
   mock = require('mongodb-mock-server');
 
 describe('Single Timeout (mocks)', function() {
+  before(function() {
+    if (this.configuration.usingUnifiedTopology()) {
+      // The new SDAM layer always reconnects, so these tests are no longer relevant.
+      return this.skip();
+    }
+  });
+
   afterEach(() => mock.cleanup());
 
   it('Should correctly timeout socket operation and then correctly re-execute', {
@@ -110,7 +117,6 @@ describe('Single Timeout (mocks)', function() {
 
     test: function(done) {
       const config = this.configuration;
-
       // Current index for the ismaster
       var currentStep = 0;
       // Should fail due to broken pipe


### PR DESCRIPTION
This is a PR resulting from lessons learned when fixing memory leaks in the old `mongos` topology implementation. Along the way, I discovered we never actually ran the test suite in core against the new SDAM implementation, so that has been added as well here. 