### PR TITLE
refactor(wire-protocol): modernize and clean wire protocol

### DIFF
--- a/lib/connection/commands.js
+++ b/lib/connection/commands.js
@@ -22,7 +22,7 @@ var OPTS_EXHAUST = 64;
 var OPTS_PARTIAL = 128;
 
 // Response flags
-var CURSOR_NOT_FOUND = 0;
+var CURSOR_NOT_FOUND = 1;
 var QUERY_FAILURE = 2;
 var SHARD_CONFIG_STALE = 4;
 var AWAIT_CAPABLE = 8;

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -107,7 +107,7 @@ var Cursor = function(bson, ns, cmd, options, topology, topologyOptions) {
     currentLimit: 0,
     // Result field name if not a cursor (contains the array of results)
     transforms: options.transforms,
-    raw: options.raw || (typeof cmd === 'object' && cmd.raw)
+    raw: options.raw || (cmd && cmd.raw)
   };
 
   if (typeof options.session === 'object') {

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -214,8 +214,6 @@ var handleCallback = function(callback, err, result) {
 Cursor.prototype._getmore = function(callback) {
   if (this.logger.isDebug())
     this.logger.debug(f('schedule getMore call for query [%s]', JSON.stringify(this.query)));
-  // Determine if it's a raw query
-  var raw = this.options.raw || this.cmd.raw;
 
   // Set the current batchSize
   var batchSize = this.cursorState.batchSize;
@@ -235,7 +233,6 @@ Cursor.prototype._getmore = function(callback) {
     this.ns,
     this.cursorState,
     batchSize,
-    raw,
     pool,
     this.options,
     callback

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -119,7 +119,6 @@ WireProtocol.prototype.getMore = function(
   ns,
   cursorState,
   batchSize,
-  raw,
   connection,
   options,
   callback

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var copy = require('../connection/utils').copy,
-  retrieveBSON = require('../connection/utils').retrieveBSON,
-  KillCursor = require('../connection/commands').KillCursor,
-  GetMore = require('../connection/commands').GetMore,
-  Query = require('../connection/commands').Query,
-  f = require('util').format,
-  MongoError = require('../error').MongoError,
-  getReadPreference = require('./shared').getReadPreference;
+const copy = require('../connection/utils').copy;
+const retrieveBSON = require('../connection/utils').retrieveBSON;
+const KillCursor = require('../connection/commands').KillCursor;
+const GetMore = require('../connection/commands').GetMore;
+const Query = require('../connection/commands').Query;
+const f = require('util').format;
+const MongoError = require('../error').MongoError;
+const getReadPreference = require('./shared').getReadPreference;
+const applyCommonQueryOptions = require('./shared').applyCommonQueryOptions;
 
-var BSON = retrieveBSON(),
-  Long = BSON.Long;
+const BSON = retrieveBSON();
+const Long = BSON.Long;
 
 var WireProtocol = function() {};
 
@@ -149,29 +150,7 @@ WireProtocol.prototype.getMore = function(
   };
 
   // Contains any query options
-  var queryOptions = {};
-
-  // If we have a raw query decorate the function
-  if (raw) {
-    queryOptions.raw = raw;
-  }
-
-  // Check if we need to promote longs
-  if (typeof cursorState.promoteLongs === 'boolean') {
-    queryOptions.promoteLongs = cursorState.promoteLongs;
-  }
-
-  if (typeof cursorState.promoteValues === 'boolean') {
-    queryOptions.promoteValues = cursorState.promoteValues;
-  }
-
-  if (typeof cursorState.promoteBuffers === 'boolean') {
-    queryOptions.promoteBuffers = cursorState.promoteBuffers;
-  }
-
-  if (typeof cursorState.session === 'object') {
-    queryOptions.session = cursorState.session;
-  }
+  const queryOptions = applyCommonQueryOptions({}, cursorState);
 
   // Write out the getMore command
   connection.write(getMore, queryOptions, queryCallback);

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -9,6 +9,7 @@ const BSON = retrieveBSON();
 const Long = BSON.Long;
 const ReadPreference = require('../topologies/read_preference');
 const TxnState = require('../transactions').TxnState;
+const applyCommonQueryOptions = require('./shared').applyCommonQueryOptions;
 
 const WireProtocol = function() {};
 
@@ -312,33 +313,10 @@ WireProtocol.prototype.getMore = function(
     callback(null, r.documents[0], r.connection);
   }
 
-  // Query options
-  const queryOptions = { command: true };
-
-  // If we have a raw query decorate the function
-  if (raw) {
-    queryOptions.raw = raw;
-  }
-
-  // Add the result field needed
-  queryOptions.documentsReturnedIn = 'nextBatch';
-
-  // Check if we need to promote longs
-  if (typeof cursorState.promoteLongs === 'boolean') {
-    queryOptions.promoteLongs = cursorState.promoteLongs;
-  }
-
-  if (typeof cursorState.promoteValues === 'boolean') {
-    queryOptions.promoteValues = cursorState.promoteValues;
-  }
-
-  if (typeof cursorState.promoteBuffers === 'boolean') {
-    queryOptions.promoteBuffers = cursorState.promoteBuffers;
-  }
-
-  if (typeof cursorState.session === 'object') {
-    queryOptions.session = cursorState.session;
-  }
+  const queryOptions = applyCommonQueryOptions(
+    { command: true, documentsReturnedIn: 'nextBatch' },
+    cursorState
+  );
 
   // Write out the getMore command
   connection.write(query, queryOptions, queryCallback);

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -240,7 +240,6 @@ WireProtocol.prototype.getMore = function(
   ns,
   cursorState,
   batchSize,
-  raw,
   connection,
   options,
   callback
@@ -288,7 +287,7 @@ WireProtocol.prototype.getMore = function(
     }
 
     // Raw, return all the extracted documents
-    if (raw) {
+    if (cursorState.raw) {
       cursorState.documents = r.documents;
       cursorState.cursorId = r.cursorId;
       return callback(null, r.documents);

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -372,12 +372,6 @@ WireProtocol.prototype.command = function(bson, ns, cmd, cursorState, topology, 
     return query;
   }
 
-  // optionally decorate query with transaction data
-  const err = decorateWithSessionsData(query.query, options.session, options);
-  if (err) {
-    return err;
-  }
-
   return query;
 };
 

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -49,7 +49,7 @@ class WireProtocol {
       const response = result.message;
 
       // If we have a timed out query, or a cursor that was killed
-      if (response.cursorNotFounds) {
+      if (response.cursorNotFound) {
         if (typeof callback !== 'function') return;
         return callback(new MongoNetworkError('cursor killed or timed out'), null);
       }

--- a/lib/wireprotocol/shared.js
+++ b/lib/wireprotocol/shared.js
@@ -49,12 +49,18 @@ var parseHeader = function(message) {
 
 function applyCommonQueryOptions(queryOptions, cursorState) {
   if (cursorState.raw) queryOptions.raw = cursorState.raw;
-  if (typeof cursorState.promoteLongs === 'boolean')
+  if (typeof cursorState.promoteLongs === 'boolean') {
     queryOptions.promoteLongs = cursorState.promoteLongs;
-  if (typeof cursorState.promoteValues === 'boolean')
+  }
+
+  if (typeof cursorState.promoteValues === 'boolean') {
     queryOptions.promoteValues = cursorState.promoteValues;
-  if (typeof cursorState.promoteBuffers === 'boolean')
+  }
+
+  if (typeof cursorState.promoteBuffers === 'boolean') {
     queryOptions.promoteBuffers = cursorState.promoteBuffers;
+  }
+
   if (typeof cursorState.session === 'object') queryOptions.session = cursorState.session;
   return queryOptions;
 }

--- a/lib/wireprotocol/shared.js
+++ b/lib/wireprotocol/shared.js
@@ -47,9 +47,22 @@ var parseHeader = function(message) {
   };
 };
 
+function applyCommonQueryOptions(queryOptions, cursorState) {
+  if (cursorState.raw) queryOptions.raw = cursorState.raw;
+  if (typeof cursorState.promoteLongs === 'boolean')
+    queryOptions.promoteLongs = cursorState.promoteLongs;
+  if (typeof cursorState.promoteValues === 'boolean')
+    queryOptions.promoteValues = cursorState.promoteValues;
+  if (typeof cursorState.promoteBuffers === 'boolean')
+    queryOptions.promoteBuffers = cursorState.promoteBuffers;
+  if (typeof cursorState.session === 'object') queryOptions.session = cursorState.session;
+  return queryOptions;
+}
+
 module.exports = {
   getReadPreference: getReadPreference,
   MESSAGE_HEADER_SIZE: MESSAGE_HEADER_SIZE,
   opcodes: opcodes,
-  parseHeader: parseHeader
+  parseHeader: parseHeader,
+  applyCommonQueryOptions
 };


### PR DESCRIPTION
This is a mostly cosmetic change to make the two wire protocol classes easier to reason about:
- refactor to use a common `raw` property on the cursor state
- utilizing a common function for determining common query options
- converting the wire protocols to classes to make them easier to read and determine common code