### PR TITLE
refactor(wire-protocol): `command` and `query` now take callbacks

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -732,36 +732,40 @@ function initializeCursor(cursor, callback) {
       done(result);
     };
 
-    if (cursor.cmd.find != null) {
-      cursor.query = cursor.server.wireProtocolHandler.query(
-        cursor.bson,
-        cursor.ns,
-        cursor.cmd,
-        cursor.cursorState,
-        cursor.topology,
-        cursor.options
-      );
-    } else {
-      cursor.query = cursor.server.wireProtocolHandler.command(
-        cursor.bson,
-        cursor.ns,
-        cursor.cmd,
-        cursor.cursorState,
-        cursor.topology,
-        cursor.options
-      );
-    }
-
-    if (cursor.query instanceof MongoError) {
-      return callback(cursor.query);
-    }
-
     if (cursor.logger.isDebug()) {
       cursor.logger.debug(
         `issue initial query [${JSON.stringify(cursor.cmd)}] with flags [${JSON.stringify(
           cursor.query
         )}]`
       );
+    }
+
+    if (cursor.cmd.find != null) {
+      cursor.server.wireProtocolHandler.query(
+        cursor.server.s.pool,
+        cursor.bson,
+        cursor.ns,
+        cursor.cmd,
+        cursor.cursorState,
+        cursor.topology,
+        cursor.options,
+        queryCallback
+      );
+
+      return;
+    }
+
+    cursor.query = cursor.server.wireProtocolHandler.command(
+      cursor.bson,
+      cursor.ns,
+      cursor.cmd,
+      cursor.cursorState,
+      cursor.topology,
+      cursor.options
+    );
+
+    if (cursor.query instanceof MongoError) {
+      return callback(cursor.query);
     }
 
     const queryOptions = applyCommonQueryOptions({}, cursor.cursorState);

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -755,33 +755,8 @@ Server.prototype.command = function(ns, cmd, options, callback) {
     return callback(new MongoError(`server ${this.name} does not support collation`));
   }
 
-  // Are we executing against a specific topology
-  var topology = options.topology || {};
-  // Create the query object
-  var query = self.wireProtocolHandler.command(self.s.bson, ns, cmd, {}, topology, options);
-  if (query instanceof MongoError) {
-    return callback(query, null);
-  }
-
-  // Set slave OK of the query
-  query.slaveOk = options.readPreference ? options.readPreference.slaveOk() : false;
-
-  // Write options
-  var writeOptions = {
-    raw: typeof options.raw === 'boolean' ? options.raw : false,
-    promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
-    promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
-    promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false,
-    command: true,
-    monitoring: typeof options.monitoring === 'boolean' ? options.monitoring : false,
-    fullResult: typeof options.fullResult === 'boolean' ? options.fullResult : false,
-    requestId: query.requestId,
-    socketTimeout: typeof options.socketTimeout === 'number' ? options.socketTimeout : null,
-    session: options.session || null
-  };
-
-  // Write the operation to the pool
-  self.s.pool.write(query, writeOptions, callback);
+  const topology = options.topology || {};
+  self.wireProtocolHandler.command(self.s.pool, self.s.bson, ns, cmd, topology, options, callback);
 };
 
 /**

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -74,12 +74,18 @@ class WireProtocol {
     connection.write(getMore, queryOptions, queryCallback);
   }
 
-  query(bson, ns, cmd, cursorState, topology, options) {
+  query(pool, bson, ns, cmd, cursorState, topology, options, callback) {
     if (cursorState.cursorId != null) {
       return;
     }
 
-    return setupClassicFind(bson, ns, cmd, cursorState, topology, options);
+    const query = setupClassicFind(bson, ns, cmd, cursorState, topology, options);
+    const queryOptions = applyCommonQueryOptions({}, cursorState);
+    if (typeof query.documentsReturnedIn === 'string') {
+      queryOptions.documentsReturnedIn = query.documentsReturnedIn;
+    }
+
+    pool.write(query, queryOptions, callback);
   }
 
   command(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/shared.js
+++ b/lib/wireprotocol/shared.js
@@ -47,21 +47,24 @@ var parseHeader = function(message) {
   };
 };
 
-function applyCommonQueryOptions(queryOptions, cursorState) {
-  if (cursorState.raw) queryOptions.raw = cursorState.raw;
-  if (typeof cursorState.promoteLongs === 'boolean') {
-    queryOptions.promoteLongs = cursorState.promoteLongs;
+function applyCommonQueryOptions(queryOptions, options) {
+  Object.assign(queryOptions, {
+    raw: typeof options.raw === 'boolean' ? options.raw : false,
+    promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
+    promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
+    promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false,
+    monitoring: typeof options.monitoring === 'boolean' ? options.monitoring : false,
+    fullResult: typeof options.fullResult === 'boolean' ? options.fullResult : false
+  });
+
+  if (typeof options.socketTimeout === 'number') {
+    queryOptions.socketTimeout = options.socketTimeout;
   }
 
-  if (typeof cursorState.promoteValues === 'boolean') {
-    queryOptions.promoteValues = cursorState.promoteValues;
+  if (options.session) {
+    queryOptions.session = options.session;
   }
 
-  if (typeof cursorState.promoteBuffers === 'boolean') {
-    queryOptions.promoteBuffers = cursorState.promoteBuffers;
-  }
-
-  if (typeof cursorState.session === 'object') queryOptions.session = cursorState.session;
   return queryOptions;
 }
 


### PR DESCRIPTION
This completes the work to make a semi-consistent api across all methods on `WireProtocol`, opening up the door for even further consolidation of the codebase here (perhaps `WireProtocolBase`, and switching between `OP_QUERY` and `OP_MSG`)