### PR TITLE
fix(mongos-replset): pass connect options to child server instances

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -286,7 +286,7 @@ Mongos.prototype.connect = function(options) {
   // Create server instances
   var servers = this.s.seedlist.map(function(x) {
     const server = new Server(
-      Object.assign({}, self.s.options, x, {
+      Object.assign({}, self.s.options, x, options, {
         authProviders: self.authProviders,
         reconnect: false,
         monitoring: false,

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -960,12 +960,14 @@ ReplSet.prototype.connect = function(options) {
   var self = this;
   // Add any connect level options to the internal state
   this.s.connectOptions = options || {};
+
   // Set connecting state
   stateTransition(this, CONNECTING);
+
   // Create server instances
   var servers = this.s.seedlist.map(function(x) {
     return new Server(
-      Object.assign({}, self.s.options, x, {
+      Object.assign({}, self.s.options, x, options, {
         authProviders: self.authProviders,
         reconnect: false,
         monitoring: false,

--- a/test/tests/unit/replset/compression_tests.js
+++ b/test/tests/unit/replset/compression_tests.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const ReplSet = require('../../../../lib/topologies/replset');
+const mock = require('mongodb-mock-server');
+const ReplSetFixture = require('../common').ReplSetFixture;
+const expect = require('chai').expect;
+
+describe('Compression (ReplSet)', function() {
+  let test;
+  before(() => (test = new ReplSetFixture()));
+  afterEach(() => mock.cleanup());
+  beforeEach(() => test.setup());
+
+  it('should pass compression information to child server instances on connect', function(done) {
+    const compressionData = [];
+    test.primaryServer.setMessageHandler(request => {
+      const doc = request.document;
+      if (doc.ismaster) {
+        compressionData.push(doc.compression);
+        request.reply(test.primaryStates[0]);
+      }
+    });
+
+    test.firstSecondaryServer.setMessageHandler(request => {
+      const doc = request.document;
+      if (doc.ismaster) {
+        compressionData.push(doc.compression);
+        request.reply(test.firstSecondaryStates[0]);
+      }
+    });
+
+    const replSet = new ReplSet(
+      [test.primaryServer.address(), test.firstSecondaryServer.address()],
+      {
+        setName: 'rs',
+        haInterval: 10000,
+        connectionTimeout: 3000,
+        secondaryOnlyConnectionAllowed: true,
+        size: 1
+      }
+    );
+
+    replSet.on('fullsetup', () => {
+      compressionData.forEach(data => {
+        expect(data).to.eql(['zlib']);
+      });
+
+      done();
+    });
+
+    replSet.connect({ compression: { compressors: ['zlib'] } });
+  });
+});


### PR DESCRIPTION
This allows for options determined during uri parsing to make it
down to the creation of child Server instances using the legacy
SDAM topology classes.

NODE-1798