### PR TITLE
refactor(wire-protocol): simplify and make consistent signatures

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -223,16 +223,11 @@ Cursor.prototype._getmore = function(callback) {
     batchSize = this.cursorState.limit - this.cursorState.currentLimit;
   }
 
-  // Default pool
-  var pool = this.server.s.pool;
-
-  // We have a wire protocol handler
   this.server.wireProtocolHandler.getMore(
-    this.bson,
+    this.server,
     this.ns,
     this.cursorState,
     batchSize,
-    pool,
     this.options,
     callback
   );
@@ -344,10 +339,7 @@ Cursor.prototype.kill = function(callback) {
     return;
   }
 
-  // Default pool
-  var pool = this.server.s.pool;
-  // Execute command
-  this.server.wireProtocolHandler.killCursor(this.bson, this.ns, this.cursorState, pool, callback);
+  this.server.wireProtocolHandler.killCursor(this.server, this.ns, this.cursorState, callback);
 };
 
 /**
@@ -741,12 +733,10 @@ function initializeCursor(cursor, callback) {
 
     if (cursor.cmd.find != null) {
       cursor.server.wireProtocolHandler.query(
-        cursor.server.s.pool,
-        cursor.bson,
+        cursor.server,
         cursor.ns,
         cursor.cmd,
         cursor.cursorState,
-        cursor.topology,
         cursor.options,
         queryCallback
       );
@@ -755,11 +745,9 @@ function initializeCursor(cursor, callback) {
     }
 
     cursor.query = cursor.server.wireProtocolHandler.command(
-      cursor.server.s.pool,
-      cursor.bson,
+      cursor.server,
       cursor.ns,
       cursor.cmd,
-      cursor.topology,
       cursor.options,
       queryCallback
     );

--- a/lib/sdam/server.js
+++ b/lib/sdam/server.js
@@ -156,10 +156,8 @@ class Server extends EventEmitter {
       return;
     }
 
-    // Are we executing against a specific topology
-    const topology = options.topology || {};
     // Create the query object
-    const query = this.s.wireProtocolHandler.command(this.s.bson, ns, cmd, {}, topology, options);
+    const query = this.s.wireProtocolHandler.command(this, ns, cmd, {}, options);
     // Set slave OK of the query
     query.slaveOk = options.readPreference ? options.readPreference.slaveOk() : false;
 

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -755,8 +755,7 @@ Server.prototype.command = function(ns, cmd, options, callback) {
     return callback(new MongoError(`server ${this.name} does not support collation`));
   }
 
-  const topology = options.topology || {};
-  self.wireProtocolHandler.command(self.s.pool, self.s.bson, ns, cmd, topology, options, callback);
+  self.wireProtocolHandler.command(self, ns, cmd, options, callback);
 };
 
 /**
@@ -787,7 +786,7 @@ Server.prototype.insert = function(ns, ops, options, callback) {
   ops = Array.isArray(ops) ? ops : [ops];
 
   // Execute write
-  return self.wireProtocolHandler.insert(self.s.pool, ns, self.s.bson, ops, options, callback);
+  return self.wireProtocolHandler.insert(self, ns, ops, options, callback);
 };
 
 /**
@@ -822,7 +821,7 @@ Server.prototype.update = function(ns, ops, options, callback) {
   // Setup the docs as an array
   ops = Array.isArray(ops) ? ops : [ops];
   // Execute write
-  return self.wireProtocolHandler.update(self.s.pool, ns, self.s.bson, ops, options, callback);
+  return self.wireProtocolHandler.update(self, ns, ops, options, callback);
 };
 
 /**
@@ -857,7 +856,7 @@ Server.prototype.remove = function(ns, ops, options, callback) {
   // Setup the docs as an array
   ops = Array.isArray(ops) ? ops : [ops];
   // Execute write
-  return self.wireProtocolHandler.remove(self.s.pool, ns, self.s.bson, ops, options, callback);
+  return self.wireProtocolHandler.remove(self, ns, ops, options, callback);
 };
 
 /**

--- a/lib/wireprotocol/shared.js
+++ b/lib/wireprotocol/shared.js
@@ -68,10 +68,18 @@ function applyCommonQueryOptions(queryOptions, options) {
   return queryOptions;
 }
 
+function isMongos(server) {
+  if (server.type === 'mongos') return true;
+  if (server.parent && server.parent.type === 'mongos') return true;
+  // NOTE: handle unified topology
+  return false;
+}
+
 module.exports = {
-  getReadPreference: getReadPreference,
-  MESSAGE_HEADER_SIZE: MESSAGE_HEADER_SIZE,
-  opcodes: opcodes,
-  parseHeader: parseHeader,
-  applyCommonQueryOptions
+  getReadPreference,
+  MESSAGE_HEADER_SIZE,
+  opcodes,
+  parseHeader,
+  applyCommonQueryOptions,
+  isMongos
 };

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -1035,7 +1035,8 @@ describe('Server tests', function() {
     });
   });
 
-  it('Should not try to reconnect forever if reconnectTries = 0', {
+  // NOTE: skipped for flakiness
+  it.skip('Should not try to reconnect forever if reconnectTries = 0', {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {

--- a/test/tests/unit/wire_protocol_test.js
+++ b/test/tests/unit/wire_protocol_test.js
@@ -27,11 +27,12 @@ describe('WireProtocol', function() {
 
   function testPoolWrite(bypassDocumentValidation, wireProtocol, expected) {
     const pool = sinon.createStubInstance(Pool);
+    const fakeServer = { s: { pool, bson } };
     const ns = 'fake.namespace';
     const ops = [{ a: 1 }, { b: 2 }];
     const options = { bypassDocumentValidation: bypassDocumentValidation };
 
-    wireProtocol.insert(pool, ns, bson, ops, options, () => {});
+    wireProtocol.insert(fakeServer, ns, ops, options, () => {});
 
     if (expected) {
       expect(pool.write.lastCall.args[0])


### PR DESCRIPTION
All wire protocol method now just take a (selecte) server, rather
than a `pool`, `bson` and `topology` instances - these are all
housed IN a server anyway.

NODE-1799