### PR TITLE
refactor(wire-protocol): reuse `command` where possible

### DIFF
--- a/lib/connection/apm.js
+++ b/lib/connection/apm.js
@@ -90,8 +90,7 @@ const extractCommand = command => {
     }
 
     Object.keys(LEGACY_FIND_OPTIONS_MAP).forEach(key => {
-      if (typeof command.options[key] !== 'undefined')
-        result[LEGACY_FIND_OPTIONS_MAP[key]] = command.options[key];
+      if (typeof command[key] !== 'undefined') result[LEGACY_FIND_OPTIONS_MAP[key]] = command[key];
     });
 
     OP_QUERY_KEYS.forEach(key => {

--- a/lib/connection/commands.js
+++ b/lib/connection/commands.js
@@ -46,9 +46,6 @@ var Query = function(bson, ns, query, options) {
   this.ns = ns;
   this.query = query;
 
-  // Ensure empty options
-  this.options = options || {};
-
   // Additional options
   this.numberToSkip = options.numberToSkip || 0;
   this.numberToReturn = options.numberToReturn || 0;

--- a/lib/wireprotocol/shared.js
+++ b/lib/wireprotocol/shared.js
@@ -65,6 +65,10 @@ function applyCommonQueryOptions(queryOptions, options) {
     queryOptions.session = options.session;
   }
 
+  if (typeof options.documentsReturnedIn === 'string') {
+    queryOptions.documentsReturnedIn = options.documentsReturnedIn;
+  }
+
   return queryOptions;
 }
 
@@ -75,11 +79,23 @@ function isMongos(server) {
   return false;
 }
 
+function databaseNamespace(ns) {
+  return ns.split('.')[0];
+}
+function collectionNamespace(ns) {
+  return ns
+    .split('.')
+    .slice(1)
+    .join('.');
+}
+
 module.exports = {
   getReadPreference,
   MESSAGE_HEADER_SIZE,
   opcodes,
   parseHeader,
   applyCommonQueryOptions,
-  isMongos
+  isMongos,
+  databaseNamespace,
+  collectionNamespace
 };

--- a/test/tests/functional/mongos_mocks/proxy_read_preference_tests.js
+++ b/test/tests/functional/mongos_mocks/proxy_read_preference_tests.js
@@ -62,12 +62,15 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
         // Add event listeners
         server.once('fullsetup', function() {
           // Execute find
-          var cursor = server.cursor('test.test', {
-            find: 'test',
-            query: {},
-            batchSize: 2,
-            readPreference: ReadPreference.secondary
-          });
+          var cursor = server.cursor(
+            'test.test',
+            {
+              find: 'test',
+              query: {},
+              batchSize: 2
+            },
+            { readPreference: ReadPreference.secondary }
+          );
 
           // Execute next
           cursor.next(function(err, d) {
@@ -142,12 +145,15 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
         // Add event listeners
         server.once('fullsetup', function() {
           // Execute find
-          var cursor = server.cursor('test.test', {
-            find: 'test',
-            query: {},
-            batchSize: 2,
-            readPreference: new ReadPreference('nearest', [{ db: 'sf' }])
-          });
+          var cursor = server.cursor(
+            'test.test',
+            {
+              find: 'test',
+              query: {},
+              batchSize: 2
+            },
+            { readPreference: new ReadPreference('nearest', [{ db: 'sf' }]) }
+          );
 
           // Execute next
           cursor.next(function(err, d) {
@@ -214,12 +220,15 @@ describe('Mongos Proxy Read Preference (mocks)', function() {
         // Add event listeners
         server.once('connect', function() {
           // Execute find
-          var cursor = server.cursor('test.test', {
-            find: 'test',
-            query: {},
-            batchSize: 2,
-            readPreference: ReadPreference.secondary
-          });
+          var cursor = server.cursor(
+            'test.test',
+            {
+              find: 'test',
+              query: {},
+              batchSize: 2
+            },
+            { readPreference: ReadPreference.secondary }
+          );
 
           // Execute next
           cursor.next(function(err, d) {

--- a/test/tests/unit/apm_tests.js
+++ b/test/tests/unit/apm_tests.js
@@ -102,7 +102,9 @@ describe('APM tests', function() {
             $query: {
               testCmd: 1,
               fizz: 'buzz',
-              star: 'trek'
+              star: 'trek',
+              batchSize: 0,
+              skip: 0
             }
           },
           {}
@@ -150,7 +152,9 @@ describe('APM tests', function() {
         .to.have.property('command')
         .that.deep.equals({
           find: coll,
-          filter: query.query.$query
+          filter: query.query.$query,
+          batchSize: 0,
+          skip: 0
         });
     });
   });


### PR DESCRIPTION
Most of the 2.6 and 3.6 wire protocol implementations are using
commands, but they don't internally reuse the available `command`
method. This does that as much as possible, reducing a large
amount of duplicate code, and improving readability.

  - converted `killCursors` to reuse `command` (3.2 only)
  - simplify `command` options handling
  - converted `getMore` to use `command (3.2 only)
  - fix mongos sharded tests to pass read preference in as option
    not in the command
  - converted write commands to use `command` internally (2.6+3.2)
  ` converted `query` to reuse `command` (3.2 only)
  - remove needless copy of options in `Query` class (fixed apm too)
  - refactor `databaseNamespace` and `collectionNamespace` (2.6+3.2)