### PR TITLE
fix(prettier): fix prettier file paths for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run lint && mongodb-test-runner -t 60000 test/tests",
     "coverage": "node_modules/.bin/nyc node test/runner.js -t functional -l && node_modules/.bin/nyc report --reporter=text-lcov | node_modules/.bin/coveralls",
     "lint": "eslint index.js lib test",
-    "format": "prettier --print-width 100 --tab-width 2 --single-quote --write index.js 'test/**/*.js' 'lib/**/*.js'",
+    "format": "prettier --print-width 100 --tab-width 2 --single-quote --write index.js test/**/*.js lib/**/*.js",
     "changelog": "conventional-changelog -p angular -i HISTORY.md -s",
     "atlas": "node ./test/atlas.js",
     "release": "standard-version -i HISTORY.md"


### PR DESCRIPTION
Running `npm run format` on Windows only formats `index.js` because the other two paths start with single quotes which is considered an invalid path. Remove single quotes to work on both Windows & Linux