### PR TITLE
NODE-1830: reduce query instantiation

### DIFF
--- a/lib/auth/x509.js
+++ b/lib/auth/x509.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var f = require('util').format,
-  Query = require('../connection/commands').Query,
   MongoError = require('../error').MongoError;
 
 var AuthSession = function(db, username, password) {
@@ -31,7 +30,7 @@ var X509 = function(bson) {
 /**
  * Authenticate
  * @method
- * @param {{Server}|{ReplSet}|{Mongos}} server Topology the authentication method is being called on
+ * @param {function} runCommand A method called to run commands directly on a connection, bypassing any message queue
  * @param {[]Connections} connections Connections to authenticate using this authenticator
  * @param {string} db Name of the database
  * @param {string} username Username
@@ -39,7 +38,7 @@ var X509 = function(bson) {
  * @param {authResultCallback} callback The callback to return the result from the authentication
  * @return {object}
  */
-X509.prototype.auth = function(server, connections, db, username, password, callback) {
+X509.prototype.auth = function(runCommand, connections, db, username, password, callback) {
   var self = this;
   // Total connections
   var count = connections.length;
@@ -65,40 +64,33 @@ X509.prototype.auth = function(server, connections, db, username, password, call
       }
 
       // Let's start the process
-      server(
-        connection,
-        new Query(self.bson, '$external.$cmd', command, {
-          numberToSkip: 0,
-          numberToReturn: 1
-        }),
-        function(err, r) {
-          // Adjust count
-          count = count - 1;
+      runCommand(connection, '$external.$cmd', command, (err, r) => {
+        // Adjust count
+        count = count - 1;
 
-          // If we have an error
-          if (err) {
-            errorObject = err;
-          } else if (r.result['$err']) {
-            errorObject = r.result;
-          } else if (r.result['errmsg']) {
-            errorObject = r.result;
-          } else {
-            numberOfValidConnections = numberOfValidConnections + 1;
-          }
-
-          // We have authenticated all connections
-          if (count === 0 && numberOfValidConnections > 0) {
-            // Store the auth details
-            addAuthSession(self.authStore, new AuthSession(db, username, password));
-            // Return correct authentication
-            callback(null, true);
-          } else if (count === 0) {
-            if (errorObject == null)
-              errorObject = new MongoError(f('failed to authenticate using mongocr'));
-            callback(errorObject, false);
-          }
+        // If we have an error
+        if (err) {
+          errorObject = err;
+        } else if (r.result['$err']) {
+          errorObject = r.result;
+        } else if (r.result['errmsg']) {
+          errorObject = r.result;
+        } else {
+          numberOfValidConnections = numberOfValidConnections + 1;
         }
-      );
+
+        // We have authenticated all connections
+        if (count === 0 && numberOfValidConnections > 0) {
+          // Store the auth details
+          addAuthSession(self.authStore, new AuthSession(db, username, password));
+          // Return correct authentication
+          callback(null, true);
+        } else if (count === 0) {
+          if (errorObject == null)
+            errorObject = new MongoError(f('failed to authenticate using mongocr'));
+          callback(errorObject, false);
+        }
+      });
     };
 
     var _execute = function(_connection) {
@@ -140,19 +132,19 @@ X509.prototype.logout = function(dbName) {
 /**
  * Re authenticate pool
  * @method
- * @param {{Server}|{ReplSet}|{Mongos}} server Topology the authentication method is being called on
+ * @param {function} runCommand A method called to run commands directly on a connection, bypassing any message queue
  * @param {[]Connections} connections Connections to authenticate using this authenticator
  * @param {authResultCallback} callback The callback to return the result from the authentication
  * @return {object}
  */
-X509.prototype.reauthenticate = function(server, connections, callback) {
+X509.prototype.reauthenticate = function(runCommand, connections, callback) {
   var authStore = this.authStore.slice(0);
   var count = authStore.length;
   if (count === 0) return callback(null, null);
   // Iterate over all the auth details stored
   for (var i = 0; i < authStore.length; i++) {
     this.auth(
-      server,
+      runCommand,
       connections,
       authStore[i].db,
       authStore[i].username,


### PR DESCRIPTION
This is the final work required for OP_MSG support. All instantiations of `Query` have been reduced to two points in the code: the `WireProtocol` class(es), and what I'm renaming a `commandWriter` in the `Pool`. It should now be exceeding easy to switch out the `OP_QUERY` implementation for `OP_MSG` without having to impact very much of the codebase. 