### PR TITLE
NODE-1845: allow connection to be shared with mock server

### DIFF
--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -1,0 +1,172 @@
+'use strict';
+const net = require('net');
+const tls = require('tls');
+const Connection = require('./connection');
+
+function connect(messageHandler, options, callback) {
+  if (options.family !== void 0) {
+    makeConnection(options.family, options, (err, socket) => {
+      if (err) {
+        return callback(err, socket); // in the error case, `socket` is the originating error event
+      }
+
+      callback(null, new Connection(messageHandler, socket, options));
+    });
+
+    return;
+  }
+
+  return makeConnection(6, options, (err, ipv6Socket) => {
+    if (err) {
+      // if (this.logger.isDebug()) {
+      //   this.logger.debug(
+      //     `connection ${this.id} for [${this.address}] errored out with [${JSON.stringify(err)}]`
+      //   );
+      // }
+
+      makeConnection(4, options, (err, ipv4Socket) => {
+        if (err) {
+          return callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event
+        }
+
+        callback(null, new Connection(messageHandler, ipv4Socket, options));
+      });
+
+      return;
+    }
+
+    callback(null, new Connection(messageHandler, ipv6Socket, options));
+  });
+}
+
+const LEGAL_SSL_SOCKET_OPTIONS = [
+  'pfx',
+  'key',
+  'passphrase',
+  'cert',
+  'ca',
+  'ciphers',
+  'NPNProtocols',
+  'ALPNProtocols',
+  'servername',
+  'ecdhCurve',
+  'secureProtocol',
+  'secureContext',
+  'session',
+  'minDHSize'
+];
+
+function parseConnectOptions(family, options) {
+  const host = typeof options.host === 'string' ? options.host : 'localhost';
+  if (host.indexOf('/') !== -1) {
+    return { path: host };
+  }
+
+  const result = {
+    family,
+    host,
+    port: typeof options.port === 'number' ? options.port : 27017,
+    rejectUnauthorized: false
+  };
+
+  return result;
+}
+
+function parseSslOptions(family, options) {
+  const result = parseConnectOptions(family, options);
+
+  // Merge in valid SSL options
+  for (const name in options) {
+    if (options[name] != null && LEGAL_SSL_SOCKET_OPTIONS.indexOf(name) !== -1) {
+      result[name] = options[name];
+    }
+  }
+  // Set options for ssl
+  if (options.ca) result.ca = options.ca;
+  if (options.crl) result.crl = options.crl;
+  if (options.cert) result.cert = options.cert;
+  if (options.key) result.key = options.key;
+  if (options.passphrase) result.passphrase = options.passphrase;
+
+  // Override checkServerIdentity behavior
+  if (options.checkServerIdentity === false) {
+    // Skip the identiy check by retuning undefined as per node documents
+    // https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
+    result.checkServerIdentity = function() {
+      return undefined;
+    };
+  } else if (typeof options.checkServerIdentity === 'function') {
+    result.checkServerIdentity = options.checkServerIdentity;
+  }
+
+  // Set default sni servername to be the same as host
+  if (result.servername == null) {
+    result.servername = result.host;
+  }
+
+  if (typeof options.rejectUnauthorized === 'boolean') {
+    result.rejectUnauthorized = options.rejectUnauthorized;
+  }
+
+  return result;
+}
+
+function makeConnection(family, options, callback) {
+  const useSsl = typeof options.ssl === 'boolean' ? options.ssl : false;
+  const keepAlive = typeof options.keepAlive === 'boolean' ? options.keepAlive : true;
+  let keepAliveInitialDelay =
+    typeof options.keepAliveInitialDelay === 'number' ? options.keepAliveInitialDelay : 300000;
+  const noDelay = typeof options.noDelay === 'boolean' ? options.noDelay : true;
+  const connectionTimeout =
+    typeof options.connectionTimeout === 'number' ? options.connectionTimeout : 30000;
+  const socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
+  const rejectUnauthorized =
+    typeof options.rejectUnauthorized === 'boolean' ? options.rejectUnauthorized : true;
+
+  if (keepAliveInitialDelay > socketTimeout) {
+    keepAliveInitialDelay = Math.round(socketTimeout / 2);
+  }
+
+  let socket;
+  try {
+    if (useSsl) {
+      socket = tls.connect(parseSslOptions(family, options));
+    } else {
+      socket = net.createConnection(parseConnectOptions(family, options));
+    }
+  } catch (err) {
+    return callback(err);
+  }
+
+  socket.setKeepAlive(keepAlive, keepAliveInitialDelay);
+  socket.setTimeout(connectionTimeout);
+  socket.setNoDelay(noDelay);
+
+  const errorEvents = ['error', 'close', 'timeout', 'parseError', 'connect'];
+  function errorHandler(eventName) {
+    return err => {
+      if (err == null || err === false) err = true;
+      errorEvents.forEach(event => socket.removeAllListeners(event));
+      socket.removeListener('connect', connectHandler);
+      callback(err, eventName);
+    };
+  }
+
+  function connectHandler() {
+    errorEvents.forEach(event => socket.removeAllListeners(event));
+    if (socket.authorizationError && rejectUnauthorized) {
+      return callback(socket.authorizationError);
+    }
+
+    socket.setTimeout(socketTimeout);
+    callback(null, socket);
+  }
+
+  socket.once('error', errorHandler('error'));
+  socket.once('close', errorHandler('close'));
+  socket.once('timeout', errorHandler('timeout'));
+  socket.once('parseError', errorHandler('parseError'));
+  socket.once('connect', connectHandler);
+}
+
+module.exports = connect;

--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -7,7 +7,8 @@ function connect(options, callback) {
   if (options.family !== void 0) {
     makeConnection(options.family, options, (err, socket) => {
       if (err) {
-        return callback(err, socket); // in the error case, `socket` is the originating error event name
+        callback(err, socket); // in the error case, `socket` is the originating error event name
+        return;
       }
 
       callback(null, new Connection(socket, options));
@@ -20,7 +21,8 @@ function connect(options, callback) {
     if (err) {
       makeConnection(4, options, (err, ipv4Socket) => {
         if (err) {
-          return callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event name
+          callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event name
+          return;
         }
 
         callback(null, new Connection(ipv4Socket, options));

--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -7,7 +7,7 @@ function connect(options, callback) {
   if (options.family !== void 0) {
     makeConnection(options.family, options, (err, socket) => {
       if (err) {
-        return callback(err, socket); // in the error case, `socket` is the originating error event
+        return callback(err, socket); // in the error case, `socket` is the originating error event name
       }
 
       callback(null, new Connection(socket, options));
@@ -18,15 +18,9 @@ function connect(options, callback) {
 
   return makeConnection(6, options, (err, ipv6Socket) => {
     if (err) {
-      // if (this.logger.isDebug()) {
-      //   this.logger.debug(
-      //     `connection ${this.id} for [${this.address}] errored out with [${JSON.stringify(err)}]`
-      //   );
-      // }
-
       makeConnection(4, options, (err, ipv4Socket) => {
         if (err) {
-          return callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event
+          return callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event name
         }
 
         callback(null, new Connection(ipv4Socket, options));
@@ -54,7 +48,8 @@ const LEGAL_SSL_SOCKET_OPTIONS = [
   'secureContext',
   'session',
   'minDHSize',
-  'crl'
+  'crl',
+  'rejectUnauthorized'
 ];
 
 function parseConnectOptions(family, options) {
@@ -97,10 +92,6 @@ function parseSslOptions(family, options) {
   // Set default sni servername to be the same as host
   if (result.servername == null) {
     result.servername = result.host;
-  }
-
-  if (typeof options.rejectUnauthorized === 'boolean') {
-    result.rejectUnauthorized = options.rejectUnauthorized;
   }
 
   return result;

--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -3,14 +3,14 @@ const net = require('net');
 const tls = require('tls');
 const Connection = require('./connection');
 
-function connect(messageHandler, options, callback) {
+function connect(options, callback) {
   if (options.family !== void 0) {
     makeConnection(options.family, options, (err, socket) => {
       if (err) {
         return callback(err, socket); // in the error case, `socket` is the originating error event
       }
 
-      callback(null, new Connection(messageHandler, socket, options));
+      callback(null, new Connection(socket, options));
     });
 
     return;
@@ -29,13 +29,13 @@ function connect(messageHandler, options, callback) {
           return callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event
         }
 
-        callback(null, new Connection(messageHandler, ipv4Socket, options));
+        callback(null, new Connection(ipv4Socket, options));
       });
 
       return;
     }
 
-    callback(null, new Connection(messageHandler, ipv6Socket, options));
+    callback(null, new Connection(ipv6Socket, options));
   });
 }
 

--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -53,7 +53,8 @@ const LEGAL_SSL_SOCKET_OPTIONS = [
   'secureProtocol',
   'secureContext',
   'session',
-  'minDHSize'
+  'minDHSize',
+  'crl'
 ];
 
 function parseConnectOptions(family, options) {
@@ -81,12 +82,6 @@ function parseSslOptions(family, options) {
       result[name] = options[name];
     }
   }
-  // Set options for ssl
-  if (options.ca) result.ca = options.ca;
-  if (options.crl) result.crl = options.crl;
-  if (options.cert) result.cert = options.cert;
-  if (options.key) result.key = options.key;
-  if (options.passphrase) result.passphrase = options.passphrase;
 
   // Override checkServerIdentity behavior
   if (options.checkServerIdentity === false) {

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -99,7 +99,6 @@ class Connection extends EventEmitter {
     this.keepAlive = typeof options.keepAlive === 'boolean' ? options.keepAlive : true;
     this.keepAliveInitialDelay =
       typeof options.keepAliveInitialDelay === 'number' ? options.keepAliveInitialDelay : 300000;
-    this.socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
     this.connectionTimeout =
       typeof options.connectionTimeout === 'number' ? options.connectionTimeout : 30000;
     if (this.keepAliveInitialDelay > this.socketTimeout) {

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -1,25 +1,24 @@
 'use strict';
 
-var inherits = require('util').inherits,
-  EventEmitter = require('events').EventEmitter,
-  net = require('net'),
-  tls = require('tls'),
-  crypto = require('crypto'),
-  f = require('util').format,
-  debugOptions = require('./utils').debugOptions,
-  parseHeader = require('../wireprotocol/shared').parseHeader,
-  decompress = require('../wireprotocol/compression').decompress,
-  Response = require('./commands').Response,
-  BinMsg = require('./msg').BinMsg,
-  MongoNetworkError = require('../error').MongoNetworkError,
-  Logger = require('./logger'),
-  OP_COMPRESSED = require('../wireprotocol/shared').opcodes.OP_COMPRESSED,
-  OP_MSG = require('../wireprotocol/shared').opcodes.OP_MSG,
-  MESSAGE_HEADER_SIZE = require('../wireprotocol/shared').MESSAGE_HEADER_SIZE,
-  Buffer = require('safe-buffer').Buffer;
+const EventEmitter = require('events').EventEmitter;
+const net = require('net');
+const tls = require('tls');
+const crypto = require('crypto');
+const debugOptions = require('./utils').debugOptions;
+const parseHeader = require('../wireprotocol/shared').parseHeader;
+const decompress = require('../wireprotocol/compression').decompress;
+const Response = require('./commands').Response;
+const BinMsg = require('./msg').BinMsg;
+const MongoNetworkError = require('../error').MongoNetworkError;
+const MongoError = require('../error').MongoError;
+const Logger = require('./logger');
+const OP_COMPRESSED = require('../wireprotocol/shared').opcodes.OP_COMPRESSED;
+const OP_MSG = require('../wireprotocol/shared').opcodes.OP_MSG;
+const MESSAGE_HEADER_SIZE = require('../wireprotocol/shared').MESSAGE_HEADER_SIZE;
+const Buffer = require('safe-buffer').Buffer;
 
-var _id = 0;
-var debugFields = [
+let _id = 0;
+const DEBUG_FIELDS = [
   'host',
   'port',
   'size',
@@ -40,175 +39,311 @@ var debugFields = [
   'checkServerIdentity'
 ];
 
-var connectionAccountingSpy = undefined;
-var connectionAccounting = false;
-var connections = {};
+let connectionAccountingSpy = undefined;
+let connectionAccounting = false;
+let connections = {};
 
 /**
- * Creates a new Connection instance
- * @class
- * @param {string} options.host The server host
- * @param {number} options.port The server port
- * @param {number} [options.family=null] IP version for DNS lookup, passed down to Node's [`dns.lookup()` function](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback). If set to `6`, will only look for ipv6 addresses.
- * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
- * @param {number} [options.keepAliveInitialDelay=300000] Initial delay before TCP keep alive enabled
- * @param {boolean} [options.noDelay=true] TCP Connection no delay
- * @param {number} [options.connectionTimeout=30000] TCP Connection timeout setting
- * @param {number} [options.socketTimeout=360000] TCP Socket timeout setting
- * @param {boolean} [options.singleBufferSerializtion=true] Serialize into single buffer, trade of peak memory for serialization speed
- * @param {boolean} [options.ssl=false] Use SSL for connection
- * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
- * @param {Buffer} [options.ca] SSL Certificate store binary buffer
- * @param {Buffer} [options.crl] SSL Certificate revocation store binary buffer
- * @param {Buffer} [options.cert] SSL Certificate binary buffer
- * @param {Buffer} [options.key] SSL Key file binary buffer
- * @param {string} [options.passphrase] SSL Certificate pass phrase
- * @param {boolean} [options.rejectUnauthorized=true] Reject unauthorized server certificates
- * @param {boolean} [options.promoteLongs=true] Convert Long values from the db into Numbers if they fit into 53 bits
- * @param {boolean} [options.promoteValues=true] Promotes BSON values to native types where possible, set to false to only receive wrapper types.
- * @param {boolean} [options.promoteBuffers=false] Promotes Binary BSON values to native Node Buffers.
+ * A class representing a single connection to a MongoDB server
+ *
  * @fires Connection#connect
  * @fires Connection#close
  * @fires Connection#error
  * @fires Connection#timeout
  * @fires Connection#parseError
- * @return {Connection} A cursor instance
  */
-var Connection = function(messageHandler, options) {
-  // Add event listener
-  EventEmitter.call(this);
-  // Set empty if no options passed
-  this.options = options || {};
-  // Identification information
-  this.id = _id++;
-  // Logger instance
-  this.logger = Logger('Connection', options);
-  // No bson parser passed in
-  if (!options.bson) throw new Error('must pass in valid bson parser');
-  // Get bson parser
-  this.bson = options.bson;
-  // Grouping tag used for debugging purposes
-  this.tag = options.tag;
-  // Message handler
-  this.messageHandler = messageHandler;
+class Connection extends EventEmitter {
+  /**
+   * Creates a new Connection instance
+   *
+   * @param {function} messageHandler A function called each time a complete message is received off the wire
+   * @param {string} options.host The server host
+   * @param {number} options.port The server port
+   * @param {number} [options.family=null] IP version for DNS lookup, passed down to Node's [`dns.lookup()` function](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback). If set to `6`, will only look for ipv6 addresses.
+   * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
+   * @param {number} [options.keepAliveInitialDelay=300000] Initial delay before TCP keep alive enabled
+   * @param {boolean} [options.noDelay=true] TCP Connection no delay
+   * @param {number} [options.connectionTimeout=30000] TCP Connection timeout setting
+   * @param {number} [options.socketTimeout=360000] TCP Socket timeout setting
+   * @param {boolean} [options.singleBufferSerializtion=true] Serialize into single buffer, trade of peak memory for serialization speed
+   * @param {boolean} [options.ssl=false] Use SSL for connection
+   * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
+   * @param {Buffer} [options.ca] SSL Certificate store binary buffer
+   * @param {Buffer} [options.crl] SSL Certificate revocation store binary buffer
+   * @param {Buffer} [options.cert] SSL Certificate binary buffer
+   * @param {Buffer} [options.key] SSL Key file binary buffer
+   * @param {string} [options.passphrase] SSL Certificate pass phrase
+   * @param {boolean} [options.rejectUnauthorized=true] Reject unauthorized server certificates
+   * @param {boolean} [options.promoteLongs=true] Convert Long values from the db into Numbers if they fit into 53 bits
+   * @param {boolean} [options.promoteValues=true] Promotes BSON values to native types where possible, set to false to only receive wrapper types.
+   * @param {boolean} [options.promoteBuffers=false] Promotes Binary BSON values to native Node Buffers.
+   */
+  constructor(messageHandler, options) {
+    super();
 
-  // Max BSON message size
-  this.maxBsonMessageSize = options.maxBsonMessageSize || 1024 * 1024 * 16 * 4;
-  // Debug information
-  if (this.logger.isDebug())
-    this.logger.debug(
-      f(
-        'creating connection %s with options [%s]',
-        this.id,
-        JSON.stringify(debugOptions(debugFields, options))
-      )
-    );
+    options = options || {};
+    if (!options.bson) {
+      throw new TypeError('must pass in valid bson parser');
+    }
 
-  // Default options
-  this.port = options.port || 27017;
-  this.host = options.host || 'localhost';
-  this.family = typeof options.family === 'number' ? options.family : void 0;
-  this.keepAlive = typeof options.keepAlive === 'boolean' ? options.keepAlive : true;
-  this.keepAliveInitialDelay =
-    typeof options.keepAliveInitialDelay === 'number' ? options.keepAliveInitialDelay : 300000;
-  this.noDelay = typeof options.noDelay === 'boolean' ? options.noDelay : true;
-  this.connectionTimeout =
-    typeof options.connectionTimeout === 'number' ? options.connectionTimeout : 30000;
-  this.socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
+    this.id = _id++;
+    this.options = options;
+    this.logger = Logger('Connection', options);
+    this.bson = options.bson;
+    this.tag = options.tag;
+    this.messageHandler = messageHandler;
+    this.maxBsonMessageSize = options.maxBsonMessageSize || 1024 * 1024 * 16 * 4;
 
-  // Is the keepAliveInitialDelay > socketTimeout set it to half of socketTimeout
-  if (this.keepAliveInitialDelay > this.socketTimeout) {
-    this.keepAliveInitialDelay = Math.round(this.socketTimeout / 2);
+    // Debug information
+    if (this.logger.isDebug()) {
+      this.logger.debug(
+        `creating connection ${this.id} with options [${JSON.stringify(
+          debugOptions(DEBUG_FIELDS, options)
+        )}]`
+      );
+    }
+
+    // Default options
+    this.port = options.port || 27017;
+    this.host = options.host || 'localhost';
+    this.family = typeof options.family === 'number' ? options.family : void 0;
+    this.keepAlive = typeof options.keepAlive === 'boolean' ? options.keepAlive : true;
+    this.keepAliveInitialDelay =
+      typeof options.keepAliveInitialDelay === 'number' ? options.keepAliveInitialDelay : 300000;
+    this.noDelay = typeof options.noDelay === 'boolean' ? options.noDelay : true;
+    this.connectionTimeout =
+      typeof options.connectionTimeout === 'number' ? options.connectionTimeout : 30000;
+    this.socketTimeout = typeof options.socketTimeout === 'number' ? options.socketTimeout : 360000;
+
+    // Is the keepAliveInitialDelay > socketTimeout set it to half of socketTimeout
+    if (this.keepAliveInitialDelay > this.socketTimeout) {
+      this.keepAliveInitialDelay = Math.round(this.socketTimeout / 2);
+    }
+
+    this.destroyed = false;
+    this.domainSocket = this.host.indexOf('/') !== -1;
+    this.singleBufferSerializtion =
+      typeof options.singleBufferSerializtion === 'boolean'
+        ? options.singleBufferSerializtion
+        : true;
+    this.serializationFunction = this.singleBufferSerializtion ? 'toBinUnified' : 'toBin';
+
+    // SSL options
+    this.ca = options.ca || null;
+    this.crl = options.crl || null;
+    this.cert = options.cert || null;
+    this.key = options.key || null;
+    this.passphrase = options.passphrase || null;
+    this.ciphers = options.ciphers || null;
+    this.ecdhCurve = options.ecdhCurve || null;
+    this.ssl = typeof options.ssl === 'boolean' ? options.ssl : false;
+    this.rejectUnauthorized =
+      typeof options.rejectUnauthorized === 'boolean' ? options.rejectUnauthorized : true;
+    this.checkServerIdentity =
+      typeof options.checkServerIdentity === 'boolean' ||
+      typeof options.checkServerIdentity === 'function'
+        ? options.checkServerIdentity
+        : true;
+
+    // If ssl not enabled
+    if (!this.ssl) {
+      this.rejectUnauthorized = false;
+    }
+
+    // Response options
+    this.responseOptions = {
+      promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
+      promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
+      promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false
+    };
+
+    // Flushing
+    this.flushing = false;
+    this.queue = [];
+
+    // Internal state
+    this.connection = null;
+    this.writeStream = null;
+
+    // Create hash method
+    const hash = crypto.createHash('sha1');
+    hash.update(this.address);
+    this.hashedName = hash.digest('hex');
+
+    // All operations in flight on the connection
+    this.workItems = [];
   }
 
-  // If connection was destroyed
-  this.destroyed = false;
-
-  // Check if we have a domain socket
-  this.domainSocket = this.host.indexOf('/') !== -1;
-
-  // Serialize commands using function
-  this.singleBufferSerializtion =
-    typeof options.singleBufferSerializtion === 'boolean' ? options.singleBufferSerializtion : true;
-  this.serializationFunction = this.singleBufferSerializtion ? 'toBinUnified' : 'toBin';
-
-  // SSL options
-  this.ca = options.ca || null;
-  this.crl = options.crl || null;
-  this.cert = options.cert || null;
-  this.key = options.key || null;
-  this.passphrase = options.passphrase || null;
-  this.ciphers = options.ciphers || null;
-  this.ecdhCurve = options.ecdhCurve || null;
-  this.ssl = typeof options.ssl === 'boolean' ? options.ssl : false;
-  this.rejectUnauthorized =
-    typeof options.rejectUnauthorized === 'boolean' ? options.rejectUnauthorized : true;
-  this.checkServerIdentity =
-    typeof options.checkServerIdentity === 'boolean' ||
-    typeof options.checkServerIdentity === 'function'
-      ? options.checkServerIdentity
-      : true;
-
-  // If ssl not enabled
-  if (!this.ssl) this.rejectUnauthorized = false;
-
-  // Response options
-  this.responseOptions = {
-    promoteLongs: typeof options.promoteLongs === 'boolean' ? options.promoteLongs : true,
-    promoteValues: typeof options.promoteValues === 'boolean' ? options.promoteValues : true,
-    promoteBuffers: typeof options.promoteBuffers === 'boolean' ? options.promoteBuffers : false
-  };
-
-  // Flushing
-  this.flushing = false;
-  this.queue = [];
-
-  // Internal state
-  this.connection = null;
-  this.writeStream = null;
-
-  // Create hash method
-  var hash = crypto.createHash('sha1');
-  hash.update(f('%s:%s', this.host, this.port));
-
-  // Create a hash name
-  this.hashedName = hash.digest('hex');
-
-  // All operations in flight on the connection
-  this.workItems = [];
-};
-
-inherits(Connection, EventEmitter);
-
-Connection.prototype.setSocketTimeout = function(value) {
-  if (this.connection) {
-    this.connection.setTimeout(value);
-  }
-};
-
-Connection.prototype.resetSocketTimeout = function() {
-  if (this.connection) {
-    this.connection.setTimeout(this.socketTimeout);
-  }
-};
-
-Connection.enableConnectionAccounting = function(spy) {
-  if (spy) {
-    connectionAccountingSpy = spy;
+  setSocketTimeout(value) {
+    if (this.connection) {
+      this.connection.setTimeout(value);
+    }
   }
 
-  connectionAccounting = true;
-  connections = {};
-};
+  resetSocketTimeout() {
+    if (this.connection) {
+      this.connection.setTimeout(this.socketTimeout);
+    }
+  }
 
-Connection.disableConnectionAccounting = function() {
-  connectionAccounting = false;
-  connectionAccountingSpy = undefined;
-};
+  static enableConnectionAccounting(spy) {
+    if (spy) {
+      connectionAccountingSpy = spy;
+    }
 
-Connection.connections = function() {
-  return connections;
-};
+    connectionAccounting = true;
+    connections = {};
+  }
+
+  static disableConnectionAccounting() {
+    connectionAccounting = false;
+    connectionAccountingSpy = undefined;
+  }
+
+  static connections() {
+    return connections;
+  }
+
+  get address() {
+    return `${this.host}:${this.port}`;
+  }
+
+  /**
+   * Connect
+   * @method
+   */
+  connect(_options) {
+    _options = _options || {};
+    // Set the connections
+    if (connectionAccounting) addConnection(this.id, this);
+    // Check if we are overriding the promoteLongs
+    if (typeof _options.promoteLongs === 'boolean') {
+      this.responseOptions.promoteLongs = _options.promoteLongs;
+      this.responseOptions.promoteValues = _options.promoteValues;
+      this.responseOptions.promoteBuffers = _options.promoteBuffers;
+    }
+
+    const _errorHandler = errorHandler(this);
+
+    if (this.family !== void 0) {
+      return doConnect(this, this.family, _options, _errorHandler);
+    }
+
+    return doConnect(this, 6, _options, err => {
+      if (this.logger.isDebug()) {
+        this.logger.debug(
+          `connection ${this.id} for [${this.address}] errored out with [${JSON.stringify(err)}]`
+        );
+      }
+
+      // clean up existing event handlers
+      this.connection.removeAllListeners('error');
+      this.connection.removeAllListeners('timeout');
+      this.connection.removeAllListeners('close');
+      this.connection.removeAllListeners('data');
+      this.connection = undefined;
+
+      return doConnect(this, 4, _options, _errorHandler);
+    });
+  }
+
+  /**
+   * Unref this connection
+   * @method
+   * @return {boolean}
+   */
+  unref() {
+    if (this.connection == null) {
+      this.once('connect', () => this.connection.unref());
+      return;
+    }
+
+    this.connection.unref();
+  }
+
+  /**
+   * Destroy connection
+   * @method
+   */
+  destroy() {
+    // Set the connections
+    if (connectionAccounting) deleteConnection(this.id);
+    if (this.connection) {
+      // Catch posssible exception thrown by node 0.10.x
+      try {
+        this.connection.end();
+      } catch (err) {} // eslint-disable-line
+      // Destroy connection
+      this.connection.destroy();
+    }
+
+    this.destroyed = true;
+  }
+
+  /**
+   * Write to connection
+   * @method
+   * @param {Command} command Command to write out need to implement toBin and toBinUnified
+   */
+  write(buffer) {
+    // Debug Log
+    if (this.logger.isDebug()) {
+      if (!Array.isArray(buffer)) {
+        this.logger.debug(`writing buffer [${buffer.toString('hex')}] to ${this.address}`);
+      } else {
+        for (let i = 0; i < buffer.length; i++)
+          this.logger.debug(`writing buffer [${buffer[i].toString('hex')}] to ${this.address}`);
+      }
+    }
+
+    // Double check that the connection is not destroyed
+    if (this.connection.destroyed === false) {
+      // Write out the command
+      if (!Array.isArray(buffer)) {
+        this.connection.write(buffer, 'binary');
+        return true;
+      }
+
+      // Iterate over all buffers and write them in order to the socket
+      for (let i = 0; i < buffer.length; i++) {
+        this.connection.write(buffer[i], 'binary');
+      }
+
+      return true;
+    }
+
+    // Connection is destroyed return write failed
+    return false;
+  }
+
+  /**
+   * Return id of connection as a string
+   * @method
+   * @return {string}
+   */
+  toString() {
+    return '' + this.id;
+  }
+
+  /**
+   * Return json object of connection
+   * @method
+   * @return {object}
+   */
+  toJSON() {
+    return { id: this.id, host: this.host, port: this.port };
+  }
+
+  /**
+   * Is the connection connected
+   * @method
+   * @return {boolean}
+   */
+  isConnected() {
+    if (this.destroyed) return false;
+    return !this.connection.destroyed && this.connection.writable;
+  }
+}
 
 function deleteConnection(id) {
   // console.log("=== deleted connection " + id + " :: " + (connections[id] ? connections[id].port : ''))
@@ -230,242 +365,248 @@ function addConnection(id, connection) {
 
 //
 // Connection handlers
-var errorHandler = function(self) {
+function errorHandler(conn) {
   return function(err) {
-    if (connectionAccounting) deleteConnection(self.id);
+    if (connectionAccounting) deleteConnection(conn.id);
     // Debug information
-    if (self.logger.isDebug())
-      self.logger.debug(
-        f(
-          'connection %s for [%s:%s] errored out with [%s]',
-          self.id,
-          self.host,
-          self.port,
-          JSON.stringify(err)
-        )
+    if (conn.logger.isDebug()) {
+      conn.logger.debug(
+        `connection ${conn.id} for [${conn.address}] errored out with [${JSON.stringify(err)}]`
       );
-    // Emit the error
-    if (self.listeners('error').length > 0) self.emit('error', new MongoNetworkError(err), self);
-  };
-};
+    }
 
-var timeoutHandler = function(self) {
+    conn.emit('error', new MongoNetworkError(err), conn);
+  };
+}
+
+function timeoutHandler(conn) {
   return function() {
-    if (connectionAccounting) deleteConnection(self.id);
-    // Debug information
-    if (self.logger.isDebug())
-      self.logger.debug(f('connection %s for [%s:%s] timed out', self.id, self.host, self.port));
-    // Emit timeout error
-    self.emit(
+    if (connectionAccounting) deleteConnection(conn.id);
+
+    if (conn.logger.isDebug()) {
+      conn.logger.debug(`connection ${conn.id} for [${conn.address}] timed out`);
+    }
+
+    conn.emit(
       'timeout',
-      new MongoNetworkError(f('connection %s to %s:%s timed out', self.id, self.host, self.port)),
-      self
+      new MongoNetworkError(`connection ${conn.id} to ${conn.address} timed out`),
+      conn
     );
   };
-};
+}
 
-var closeHandler = function(self) {
+function closeHandler(conn) {
   return function(hadError) {
-    if (connectionAccounting) deleteConnection(self.id);
-    // Debug information
-    if (self.logger.isDebug())
-      self.logger.debug(f('connection %s with for [%s:%s] closed', self.id, self.host, self.port));
+    if (connectionAccounting) deleteConnection(conn.id);
 
-    // Emit close event
+    if (conn.logger.isDebug()) {
+      conn.logger.debug(`connection ${conn.id} with for [${conn.address}] closed`);
+    }
+
     if (!hadError) {
-      self.emit(
+      conn.emit(
         'close',
-        new MongoNetworkError(f('connection %s to %s:%s closed', self.id, self.host, self.port)),
-        self
+        new MongoNetworkError(`connection ${conn.id} to ${conn.address} closed`),
+        conn
       );
     }
   };
-};
+}
 
 // Handle a message once it is received
-var emitMessageHandler = function(self, message) {
-  var msgHeader = parseHeader(message);
-  if (msgHeader.opCode === OP_COMPRESSED) {
-    msgHeader.fromCompressed = true;
-    var index = MESSAGE_HEADER_SIZE;
-    msgHeader.opCode = message.readInt32LE(index);
-    index += 4;
-    msgHeader.length = message.readInt32LE(index);
-    index += 4;
-    var compressorID = message[index];
-    index++;
-    decompress(compressorID, message.slice(index), function(err, decompressedMsgBody) {
-      if (err) {
-        throw err;
-      }
-      if (decompressedMsgBody.length !== msgHeader.length) {
-        throw new Error(
-          'Decompressing a compressed message from the server failed. The message is corrupt.'
-        );
-      }
-      const ResponseConstructor = msgHeader.opCode === OP_MSG ? BinMsg : Response;
-      self.messageHandler(
-        new ResponseConstructor(
-          self.bson,
-          message,
-          msgHeader,
-          decompressedMsgBody,
-          self.responseOptions
-        ),
-        self
-      );
-    });
-  } else {
+function processMessage(conn, message) {
+  const msgHeader = parseHeader(message);
+  if (msgHeader.opCode !== OP_COMPRESSED) {
     const ResponseConstructor = msgHeader.opCode === OP_MSG ? BinMsg : Response;
-    self.messageHandler(
+    conn.messageHandler(
       new ResponseConstructor(
-        self.bson,
+        conn.bson,
         message,
         msgHeader,
         message.slice(MESSAGE_HEADER_SIZE),
-        self.responseOptions
+        conn.responseOptions
       ),
-      self
+      conn
     );
-  }
-};
 
-var dataHandler = function(self) {
+    return;
+  }
+
+  msgHeader.fromCompressed = true;
+  let index = MESSAGE_HEADER_SIZE;
+  msgHeader.opCode = message.readInt32LE(index);
+  index += 4;
+  msgHeader.length = message.readInt32LE(index);
+  index += 4;
+  const compressorID = message[index];
+  index++;
+
+  decompress(compressorID, message.slice(index), function(err, decompressedMsgBody) {
+    if (err) {
+      conn.emit('error', err);
+      return;
+    }
+
+    if (decompressedMsgBody.length !== msgHeader.length) {
+      conn.emit(
+        'error',
+        new MongoError(
+          'Decompressing a compressed message from the server failed. The message is corrupt.'
+        )
+      );
+
+      return;
+    }
+
+    const ResponseConstructor = msgHeader.opCode === OP_MSG ? BinMsg : Response;
+    conn.messageHandler(
+      new ResponseConstructor(
+        conn.bson,
+        message,
+        msgHeader,
+        decompressedMsgBody,
+        conn.responseOptions
+      ),
+      conn
+    );
+  });
+}
+
+function dataHandler(conn) {
   return function(data) {
     // Parse until we are done with the data
     while (data.length > 0) {
       // If we still have bytes to read on the current message
-      if (self.bytesRead > 0 && self.sizeOfMessage > 0) {
+      if (conn.bytesRead > 0 && conn.sizeOfMessage > 0) {
         // Calculate the amount of remaining bytes
-        var remainingBytesToRead = self.sizeOfMessage - self.bytesRead;
+        const remainingBytesToRead = conn.sizeOfMessage - conn.bytesRead;
         // Check if the current chunk contains the rest of the message
         if (remainingBytesToRead > data.length) {
           // Copy the new data into the exiting buffer (should have been allocated when we know the message size)
-          data.copy(self.buffer, self.bytesRead);
+          data.copy(conn.buffer, conn.bytesRead);
           // Adjust the number of bytes read so it point to the correct index in the buffer
-          self.bytesRead = self.bytesRead + data.length;
+          conn.bytesRead = conn.bytesRead + data.length;
 
           // Reset state of buffer
           data = Buffer.alloc(0);
         } else {
           // Copy the missing part of the data into our current buffer
-          data.copy(self.buffer, self.bytesRead, 0, remainingBytesToRead);
+          data.copy(conn.buffer, conn.bytesRead, 0, remainingBytesToRead);
           // Slice the overflow into a new buffer that we will then re-parse
           data = data.slice(remainingBytesToRead);
 
           // Emit current complete message
           try {
-            var emitBuffer = self.buffer;
+            const emitBuffer = conn.buffer;
             // Reset state of buffer
-            self.buffer = null;
-            self.sizeOfMessage = 0;
-            self.bytesRead = 0;
-            self.stubBuffer = null;
+            conn.buffer = null;
+            conn.sizeOfMessage = 0;
+            conn.bytesRead = 0;
+            conn.stubBuffer = null;
 
-            emitMessageHandler(self, emitBuffer);
+            processMessage(conn, emitBuffer);
           } catch (err) {
-            var errorObject = {
+            const errorObject = {
               err: 'socketHandler',
               trace: err,
-              bin: self.buffer,
+              bin: conn.buffer,
               parseState: {
-                sizeOfMessage: self.sizeOfMessage,
-                bytesRead: self.bytesRead,
-                stubBuffer: self.stubBuffer
+                sizeOfMessage: conn.sizeOfMessage,
+                bytesRead: conn.bytesRead,
+                stubBuffer: conn.stubBuffer
               }
             };
             // We got a parse Error fire it off then keep going
-            self.emit('parseError', errorObject, self);
+            conn.emit('parseError', errorObject, conn);
           }
         }
       } else {
         // Stub buffer is kept in case we don't get enough bytes to determine the
         // size of the message (< 4 bytes)
-        if (self.stubBuffer != null && self.stubBuffer.length > 0) {
+        if (conn.stubBuffer != null && conn.stubBuffer.length > 0) {
           // If we have enough bytes to determine the message size let's do it
-          if (self.stubBuffer.length + data.length > 4) {
+          if (conn.stubBuffer.length + data.length > 4) {
             // Prepad the data
-            var newData = Buffer.alloc(self.stubBuffer.length + data.length);
-            self.stubBuffer.copy(newData, 0);
-            data.copy(newData, self.stubBuffer.length);
+            const newData = Buffer.alloc(conn.stubBuffer.length + data.length);
+            conn.stubBuffer.copy(newData, 0);
+            data.copy(newData, conn.stubBuffer.length);
             // Reassign for parsing
             data = newData;
 
             // Reset state of buffer
-            self.buffer = null;
-            self.sizeOfMessage = 0;
-            self.bytesRead = 0;
-            self.stubBuffer = null;
+            conn.buffer = null;
+            conn.sizeOfMessage = 0;
+            conn.bytesRead = 0;
+            conn.stubBuffer = null;
           } else {
             // Add the the bytes to the stub buffer
-            var newStubBuffer = Buffer.alloc(self.stubBuffer.length + data.length);
+            const newStubBuffer = Buffer.alloc(conn.stubBuffer.length + data.length);
             // Copy existing stub buffer
-            self.stubBuffer.copy(newStubBuffer, 0);
+            conn.stubBuffer.copy(newStubBuffer, 0);
             // Copy missing part of the data
-            data.copy(newStubBuffer, self.stubBuffer.length);
+            data.copy(newStubBuffer, conn.stubBuffer.length);
             // Exit parsing loop
             data = Buffer.alloc(0);
           }
         } else {
           if (data.length > 4) {
             // Retrieve the message size
-            // var sizeOfMessage = data.readUInt32LE(0);
-            var sizeOfMessage = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
+            const sizeOfMessage = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
             // If we have a negative sizeOfMessage emit error and return
-            if (sizeOfMessage < 0 || sizeOfMessage > self.maxBsonMessageSize) {
-              errorObject = {
+            if (sizeOfMessage < 0 || sizeOfMessage > conn.maxBsonMessageSize) {
+              const errorObject = {
                 err: 'socketHandler',
                 trace: '',
-                bin: self.buffer,
+                bin: conn.buffer,
                 parseState: {
                   sizeOfMessage: sizeOfMessage,
-                  bytesRead: self.bytesRead,
-                  stubBuffer: self.stubBuffer
+                  bytesRead: conn.bytesRead,
+                  stubBuffer: conn.stubBuffer
                 }
               };
               // We got a parse Error fire it off then keep going
-              self.emit('parseError', errorObject, self);
+              conn.emit('parseError', errorObject, conn);
               return;
             }
 
             // Ensure that the size of message is larger than 0 and less than the max allowed
             if (
               sizeOfMessage > 4 &&
-              sizeOfMessage < self.maxBsonMessageSize &&
+              sizeOfMessage < conn.maxBsonMessageSize &&
               sizeOfMessage > data.length
             ) {
-              self.buffer = Buffer.alloc(sizeOfMessage);
+              conn.buffer = Buffer.alloc(sizeOfMessage);
               // Copy all the data into the buffer
-              data.copy(self.buffer, 0);
+              data.copy(conn.buffer, 0);
               // Update bytes read
-              self.bytesRead = data.length;
+              conn.bytesRead = data.length;
               // Update sizeOfMessage
-              self.sizeOfMessage = sizeOfMessage;
+              conn.sizeOfMessage = sizeOfMessage;
               // Ensure stub buffer is null
-              self.stubBuffer = null;
+              conn.stubBuffer = null;
               // Exit parsing loop
               data = Buffer.alloc(0);
             } else if (
               sizeOfMessage > 4 &&
-              sizeOfMessage < self.maxBsonMessageSize &&
+              sizeOfMessage < conn.maxBsonMessageSize &&
               sizeOfMessage === data.length
             ) {
               try {
-                emitBuffer = data;
+                const emitBuffer = data;
                 // Reset state of buffer
-                self.buffer = null;
-                self.sizeOfMessage = 0;
-                self.bytesRead = 0;
-                self.stubBuffer = null;
+                conn.buffer = null;
+                conn.sizeOfMessage = 0;
+                conn.bytesRead = 0;
+                conn.stubBuffer = null;
                 // Exit parsing loop
                 data = Buffer.alloc(0);
                 // Emit the message
-                emitMessageHandler(self, emitBuffer);
+                processMessage(conn, emitBuffer);
               } catch (err) {
-                self.emit('parseError', err, self);
+                conn.emit('parseError', err, conn);
               }
-            } else if (sizeOfMessage <= 4 || sizeOfMessage > self.maxBsonMessageSize) {
-              errorObject = {
+            } else if (sizeOfMessage <= 4 || sizeOfMessage > conn.maxBsonMessageSize) {
+              const errorObject = {
                 err: 'socketHandler',
                 trace: null,
                 bin: data,
@@ -477,32 +618,32 @@ var dataHandler = function(self) {
                 }
               };
               // We got a parse Error fire it off then keep going
-              self.emit('parseError', errorObject, self);
+              conn.emit('parseError', errorObject, conn);
 
               // Clear out the state of the parser
-              self.buffer = null;
-              self.sizeOfMessage = 0;
-              self.bytesRead = 0;
-              self.stubBuffer = null;
+              conn.buffer = null;
+              conn.sizeOfMessage = 0;
+              conn.bytesRead = 0;
+              conn.stubBuffer = null;
               // Exit parsing loop
               data = Buffer.alloc(0);
             } else {
-              emitBuffer = data.slice(0, sizeOfMessage);
+              const emitBuffer = data.slice(0, sizeOfMessage);
               // Reset state of buffer
-              self.buffer = null;
-              self.sizeOfMessage = 0;
-              self.bytesRead = 0;
-              self.stubBuffer = null;
+              conn.buffer = null;
+              conn.sizeOfMessage = 0;
+              conn.bytesRead = 0;
+              conn.stubBuffer = null;
               // Copy rest of message
               data = data.slice(sizeOfMessage);
               // Emit the message
-              emitMessageHandler(self, emitBuffer);
+              processMessage(conn, emitBuffer);
             }
           } else {
             // Create a buffer that contains the space for the non-complete message
-            self.stubBuffer = Buffer.alloc(data.length);
+            conn.stubBuffer = Buffer.alloc(data.length);
             // Copy the data to the stub buffer
-            data.copy(self.stubBuffer, 0);
+            data.copy(conn.stubBuffer, 0);
             // Exit parsing loop
             data = Buffer.alloc(0);
           }
@@ -510,10 +651,10 @@ var dataHandler = function(self) {
       }
     }
   };
-};
+}
 
 // List of socket level valid ssl options
-var legalSslSocketOptions = [
+const LEGAL_SSL_SOCKET_OPTIONS = [
   'pfx',
   'key',
   'passphrase',
@@ -532,8 +673,8 @@ var legalSslSocketOptions = [
 
 function merge(options1, options2) {
   // Merge in any allowed ssl options
-  for (var name in options2) {
-    if (options2[name] != null && legalSslSocketOptions.indexOf(name) !== -1) {
+  for (const name in options2) {
+    if (options2[name] != null && LEGAL_SSL_SOCKET_OPTIONS.indexOf(name) !== -1) {
       options1[name] = options2[name];
     }
   }
@@ -631,151 +772,6 @@ function doConnect(self, family, _options, _errorHandler) {
   self.connection.once('close', closeHandler(self));
   self.connection.on('data', dataHandler(self));
 }
-
-/**
- * Connect
- * @method
- */
-Connection.prototype.connect = function(_options) {
-  _options = _options || {};
-  // Set the connections
-  if (connectionAccounting) addConnection(this.id, this);
-  // Check if we are overriding the promoteLongs
-  if (typeof _options.promoteLongs === 'boolean') {
-    this.responseOptions.promoteLongs = _options.promoteLongs;
-    this.responseOptions.promoteValues = _options.promoteValues;
-    this.responseOptions.promoteBuffers = _options.promoteBuffers;
-  }
-
-  const _errorHandler = errorHandler(this);
-
-  if (this.family !== void 0) {
-    return doConnect(this, this.family, _options, _errorHandler);
-  }
-
-  return doConnect(this, 6, _options, err => {
-    if (this.logger.isDebug()) {
-      this.logger.debug(
-        f(
-          'connection %s for [%s:%s] errored out with [%s]',
-          this.id,
-          this.host,
-          this.port,
-          JSON.stringify(err)
-        )
-      );
-    }
-
-    // clean up existing event handlers
-    this.connection.removeAllListeners('error');
-    this.connection.removeAllListeners('timeout');
-    this.connection.removeAllListeners('close');
-    this.connection.removeAllListeners('data');
-    this.connection = undefined;
-
-    return doConnect(this, 4, _options, _errorHandler);
-  });
-};
-
-/**
- * Unref this connection
- * @method
- * @return {boolean}
- */
-Connection.prototype.unref = function() {
-  if (this.connection) this.connection.unref();
-  else {
-    var self = this;
-    this.once('connect', function() {
-      self.connection.unref();
-    });
-  }
-};
-
-/**
- * Destroy connection
- * @method
- */
-Connection.prototype.destroy = function() {
-  // Set the connections
-  if (connectionAccounting) deleteConnection(this.id);
-  if (this.connection) {
-    // Catch posssible exception thrown by node 0.10.x
-    try {
-      this.connection.end();
-    } catch (err) {} // eslint-disable-line
-    // Destroy connection
-    this.connection.destroy();
-  }
-
-  this.destroyed = true;
-};
-
-/**
- * Write to connection
- * @method
- * @param {Command} command Command to write out need to implement toBin and toBinUnified
- */
-Connection.prototype.write = function(buffer) {
-  var i;
-  // Debug Log
-  if (this.logger.isDebug()) {
-    if (!Array.isArray(buffer)) {
-      this.logger.debug(
-        f('writing buffer [%s] to %s:%s', buffer.toString('hex'), this.host, this.port)
-      );
-    } else {
-      for (i = 0; i < buffer.length; i++)
-        this.logger.debug(
-          f('writing buffer [%s] to %s:%s', buffer[i].toString('hex'), this.host, this.port)
-        );
-    }
-  }
-
-  // Double check that the connection is not destroyed
-  if (this.connection.destroyed === false) {
-    // Write out the command
-    if (!Array.isArray(buffer)) {
-      this.connection.write(buffer, 'binary');
-      return true;
-    }
-
-    // Iterate over all buffers and write them in order to the socket
-    for (i = 0; i < buffer.length; i++) this.connection.write(buffer[i], 'binary');
-    return true;
-  }
-
-  // Connection is destroyed return write failed
-  return false;
-};
-
-/**
- * Return id of connection as a string
- * @method
- * @return {string}
- */
-Connection.prototype.toString = function() {
-  return '' + this.id;
-};
-
-/**
- * Return json object of connection
- * @method
- * @return {object}
- */
-Connection.prototype.toJSON = function() {
-  return { id: this.id, host: this.host, port: this.port };
-};
-
-/**
- * Is the connection connected
- * @method
- * @return {boolean}
- */
-Connection.prototype.isConnected = function() {
-  if (this.destroyed) return false;
-  return !this.connection.destroyed && this.connection.writable;
-};
 
 /**
  * A server connect event, used to verify that the connection is up and running

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -16,6 +16,8 @@ const MESSAGE_HEADER_SIZE = require('../wireprotocol/shared').MESSAGE_HEADER_SIZ
 const Buffer = require('safe-buffer').Buffer;
 
 let _id = 0;
+
+const DEFAULT_MAX_BSON_MESSAGE_SIZE = 1024 * 1024 * 16 * 4;
 const DEBUG_FIELDS = [
   'host',
   'port',
@@ -79,7 +81,7 @@ class Connection extends EventEmitter {
     this.logger = Logger('Connection', options);
     this.bson = options.bson;
     this.tag = options.tag;
-    this.maxBsonMessageSize = options.maxBsonMessageSize || 1024 * 1024 * 16 * 4;
+    this.maxBsonMessageSize = options.maxBsonMessageSize || DEFAULT_MAX_BSON_MESSAGE_SIZE;
 
     this.port = options.port || 27017;
     this.host = options.host || 'localhost';

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -54,25 +54,17 @@ class Connection extends EventEmitter {
   /**
    * Creates a new Connection instance
    *
-   * @param {string} options.host The server host
-   * @param {number} options.port The server port
-   * @param {number} [options.family=null] IP version for DNS lookup, passed down to Node's [`dns.lookup()` function](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback). If set to `6`, will only look for ipv6 addresses.
+   * @param {Socket} socket The socket this connection wraps
+   * @param {Object} [options] Optional settings
+   * @param {string} [options.host] The host the socket is connected to
+   * @param {number} [options.port] The port used for the socket connection
    * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
    * @param {number} [options.keepAliveInitialDelay=300000] Initial delay before TCP keep alive enabled
-   * @param {boolean} [options.noDelay=true] TCP Connection no delay
    * @param {number} [options.connectionTimeout=30000] TCP Connection timeout setting
    * @param {number} [options.socketTimeout=360000] TCP Socket timeout setting
-   * @param {boolean} [options.ssl=false] Use SSL for connection
-   * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
-   * @param {Buffer} [options.ca] SSL Certificate store binary buffer
-   * @param {Buffer} [options.crl] SSL Certificate revocation store binary buffer
-   * @param {Buffer} [options.cert] SSL Certificate binary buffer
-   * @param {Buffer} [options.key] SSL Key file binary buffer
-   * @param {string} [options.passphrase] SSL Certificate pass phrase
-   * @param {boolean} [options.rejectUnauthorized=true] Reject unauthorized server certificates
-   * @param {boolean} [options.promoteLongs=true] Convert Long values from the db into Numbers if they fit into 53 bits
-   * @param {boolean} [options.promoteValues=true] Promotes BSON values to native types where possible, set to false to only receive wrapper types.
-   * @param {boolean} [options.promoteBuffers=false] Promotes Binary BSON values to native Node Buffers.
+   * @param {boolean} [options.promoteLongs] Convert Long values from the db into Numbers if they fit into 53 bits
+   * @param {boolean} [options.promoteValues] Promotes BSON values to native types where possible, set to false to only receive wrapper types.
+   * @param {boolean} [options.promoteBuffers] Promotes Binary BSON values to native Node Buffers.
    */
   constructor(socket, options) {
     super();

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -25,7 +25,6 @@ const DEBUG_FIELDS = [
   'noDelay',
   'connectionTimeout',
   'socketTimeout',
-  'singleBufferSerializtion',
   'ssl',
   'ca',
   'crl',
@@ -63,7 +62,6 @@ class Connection extends EventEmitter {
    * @param {boolean} [options.noDelay=true] TCP Connection no delay
    * @param {number} [options.connectionTimeout=30000] TCP Connection timeout setting
    * @param {number} [options.socketTimeout=360000] TCP Socket timeout setting
-   * @param {boolean} [options.singleBufferSerializtion=true] Serialize into single buffer, trade of peak memory for serialization speed
    * @param {boolean} [options.ssl=false] Use SSL for connection
    * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
    * @param {Buffer} [options.ca] SSL Certificate store binary buffer

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -385,6 +385,10 @@ function attemptReconnect(self) {
       self.connectingConnections--;
 
       if (err) {
+        if (self.logger.isDebug()) {
+          self.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
+        }
+
         self.retriesLeft = self.retriesLeft - 1;
         if (self.retriesLeft <= 0) {
           self.destroy();
@@ -705,6 +709,10 @@ Pool.prototype.connect = function(credentials) {
     self.connectingConnections--;
 
     if (err) {
+      if (self.logger.isDebug()) {
+        self.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
+      }
+
       // NOTE: when `err` exists, `connection` is actually the originating event name
       connectionFailureHandler(self, connection, err);
       return;
@@ -1276,6 +1284,10 @@ function _createConnection(self) {
     self.connectingConnections--;
 
     if (err) {
+      if (self.logger.isDebug()) {
+        self.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
+      }
+
       if (!self.reconnectId && self.options.reconnect) {
         self.reconnectId = setTimeout(attemptReconnect(self), self.options.reconnectInterval);
       }

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -160,22 +160,26 @@ var Pool = function(topology, options) {
   this.connectionIndex = 0;
 
   // event handlers
-  const self = this;
+  const pool = this;
   this._messageHandler = messageHandler(this);
   this._connectionCloseHandler = function(err) {
-    connectionFailureHandler(self, 'close', err, this);
+    const connection = this;
+    connectionFailureHandler(pool, 'close', err, connection);
   };
 
   this._connectionErrorHandler = function(err) {
-    connectionFailureHandler(self, 'error', err, this);
+    const connection = this;
+    connectionFailureHandler(pool, 'error', err, connection);
   };
 
   this._connectionTimeoutHandler = function(err) {
-    connectionFailureHandler(self, 'timeout', err, this);
+    const connection = this;
+    connectionFailureHandler(pool, 'timeout', err, connection);
   };
 
   this._connectionParseErrorHandler = function(err) {
-    connectionFailureHandler(self, 'parseError', err, this);
+    const connection = this;
+    connectionFailureHandler(pool, 'parseError', err, connection);
   };
 };
 

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -91,7 +91,6 @@ var handlers = ['connect', 'close', 'error', 'timeout', 'parseError'];
  * @param {boolean} [options.noDelay=true] TCP Connection no delay
  * @param {number} [options.connectionTimeout=1000] TCP Connection timeout setting
  * @param {number} [options.socketTimeout=0] TCP Socket timeout setting
- * @param {boolean} [options.singleBufferSerializtion=true] Serialize into single buffer, trade of peak memory for serialization speed
  * @param {boolean} [options.ssl=false] Use SSL for connection
  * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
  * @param {Buffer} [options.ca] SSL Certificate store binary buffer

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -77,7 +77,6 @@ var handlers = ['connect', 'close', 'error', 'timeout', 'parseError'];
  * @param {boolean} [options.noDelay=true] TCP Connection no delay
  * @param {number} [options.connectionTimeout=10000] TCP Connection timeout setting
  * @param {number} [options.socketTimeout=0] TCP Socket timeout setting
- * @param {boolean} [options.singleBufferSerializtion=true] Serialize into single buffer, trade of peak memory for serialization speed
  * @param {boolean} [options.ssl=false] Use SSL for connection
  * @param {boolean|function} [options.checkServerIdentity=true] Ensure we check server identify during SSL, set to false to disable checking. Only works for Node 0.12.x or higher. You can pass in a boolean or your own checkServerIdentity override function.
  * @param {Buffer} [options.ca] SSL Certificate store binary buffer

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -69,7 +69,6 @@ var debugFields = [
   'connectionTimeout',
   'checkServerIdentity',
   'socketTimeout',
-  'singleBufferSerializtion',
   'ssl',
   'ca',
   'crl',

--- a/test/tests/functional/connection_tests.js
+++ b/test/tests/functional/connection_tests.js
@@ -76,16 +76,16 @@ describe('Connection', function() {
     testCase('should connect with no family', {
       config: { host: 'localhost' },
       connect: connection => {
-        expect(connection.connection.remotePort).to.equal(server.port);
-        expect(connection.connection.remoteFamily).to.equal('IPv4');
+        expect(connection.socket.remotePort).to.equal(server.port);
+        expect(connection.socket.remoteFamily).to.equal('IPv4');
       }
     });
 
     testCase('should connect with family=4', {
       config: { host: 'localhost', family: 4 },
       connect: connection => {
-        expect(connection.connection.remotePort).to.equal(server.port);
-        expect(connection.connection.remoteFamily).to.equal('IPv4');
+        expect(connection.socket.remotePort).to.equal(server.port);
+        expect(connection.socket.remoteFamily).to.equal('IPv4');
       }
     });
 
@@ -101,8 +101,8 @@ describe('Connection', function() {
     testCase('should connect with no family', {
       config: { host: 'localhost' },
       connect: connection => {
-        expect(connection.connection.remotePort).to.equal(server.port);
-        expect(connection.connection.remoteFamily).to.equal('IPv6');
+        expect(connection.socket.remotePort).to.equal(server.port);
+        expect(connection.socket.remoteFamily).to.equal('IPv6');
       }
     });
 
@@ -119,8 +119,8 @@ describe('Connection', function() {
     testCase('should connect with family=6', {
       config: { host: 'localhost', family: 6 },
       connect: connection => {
-        expect(connection.connection.remotePort).to.equal(server.port);
-        expect(connection.connection.remoteFamily).to.equal('IPv6');
+        expect(connection.socket.remotePort).to.equal(server.port);
+        expect(connection.socket.remoteFamily).to.equal('IPv6');
       }
     });
   });

--- a/test/tests/functional/pool_tests.js
+++ b/test/tests/functional/pool_tests.js
@@ -71,7 +71,7 @@ describe('Pool tests', function() {
         process.nextTick(() => {
           // Now that we are in next tick, connection should still exist, but there
           // should be no connect listeners
-          expect(connection.connection.listenerCount('connect')).to.equal(0);
+          expect(connection.socket.listenerCount('connect')).to.equal(0);
           expect(connections).to.have.lengthOf(1);
 
           pool.destroy();
@@ -86,7 +86,7 @@ describe('Pool tests', function() {
 
       expect(pool.allConnections()).to.have.lengthOf(1);
       connection = pool.allConnections()[0];
-      expect(connection.connection.listenerCount('connect')).to.equal(1);
+      expect(connection.socket.listenerCount('connect')).to.equal(1);
     }
   });
 

--- a/test/tests/functional/pool_tests.js
+++ b/test/tests/functional/pool_tests.js
@@ -52,41 +52,26 @@ describe('Pool tests', function() {
 
   it('Should only listen on connect once', {
     metadata: { requires: { topology: 'single' } },
-
     test: function(done) {
-      // Attempt to connect
-      var pool = new Pool(null, {
+      const pool = new Pool(null, {
         host: this.configuration.host,
         port: this.configuration.port,
         bson: new Bson(),
         messageHandler: function() {}
       });
 
-      let connection;
-
-      // Add event listeners
       pool.on('connect', function() {
-        var connections = pool.allConnections();
-
         process.nextTick(() => {
-          // Now that we are in next tick, connection should still exist, but there
-          // should be no connect listeners
-          expect(connection.socket.listenerCount('connect')).to.equal(0);
+          const connections = pool.allConnections();
           expect(connections).to.have.lengthOf(1);
+          expect(connections[0].socket.listenerCount('connect')).to.equal(0);
 
           pool.destroy();
           done();
         });
       });
 
-      expect(pool.allConnections()).to.have.lengthOf(0);
-
-      // Start connection
       pool.connect();
-
-      expect(pool.allConnections()).to.have.lengthOf(1);
-      connection = pool.allConnections()[0];
-      expect(connection.socket.listenerCount('connect')).to.equal(1);
     }
   });
 
@@ -153,86 +138,17 @@ describe('Pool tests', function() {
 
       // Add event listeners
       pool.on('connect', function() {
-        for (var i = 0; i < 10; i++) {
-          var query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
+        for (var i = 0; i < 10; ++i) {
+          for (var j = 0; j < 10; ++j) {
+            const query = new Query(
+              new Bson(),
+              'system.$cmd',
+              { ismaster: true },
+              { numberToSkip: 0, numberToReturn: 1 }
+            );
 
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
-
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
-
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
-
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
-
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
-
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
-
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
-
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
-
-          query = new Query(
-            new Bson(),
-            'system.$cmd',
-            { ismaster: true },
-            { numberToSkip: 0, numberToReturn: 1 }
-          );
-          pool.write(query, messageHandler);
+            pool.write(query, messageHandler);
+          }
         }
       });
 
@@ -1136,7 +1052,7 @@ describe('Pool tests', function() {
     }
   });
 
-  it('should correctly exit _execute loop when single avialable connection is destroyed', {
+  it('should correctly exit _execute loop when single available connection is destroyed', {
     metadata: { requires: { topology: 'single' } },
 
     test: function(done) {
@@ -1169,7 +1085,7 @@ describe('Pool tests', function() {
 
           // Mark available connection as broken
           var con = pool.availableConnections[0];
-          pool.availableConnections[0].destroyed = true;
+          con.destroyed = true;
 
           // Execute ismaster should not cause cpu to start spinning
           query = new Query(

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -668,7 +668,7 @@ describe('Server tests', function() {
           setTimeout(function() {
             expect(server.s.pool.availableConnections.length).to.be.above(0);
             expect(server.s.pool.inUseConnections.length).to.equal(0);
-            expect(server.s.pool.connectingConnections.length).to.equal(0);
+            expect(server.s.pool.connectingConnections).to.equal(0);
 
             server.destroy();
             done();


### PR DESCRIPTION
Primary goals for this work (from jira ticket):
- Decouple Connection from the Pool by not passing in a messageHandler to the constructor, but use a message event instead
- Move the "connect" logic for creating and initially connection connections out of Connection into its own method, a la net.connect