### PR TITLE
NODE-1741: implement convenient transactions api (core)

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -42,6 +42,10 @@ class MongoError extends Error {
   static create(options) {
     return new MongoError(options);
   }
+
+  hasErrorLabel(label) {
+    return this.errorLabels && this.errorLabels.indexOf(label) !== -1;
+  }
 }
 
 /**

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -328,20 +328,27 @@ class ClientSession extends EventEmitter {
           return maybeRetryOrThrow(err);
         });
     }
-
-    return retryTransaction();
   }
 }
 
+const WRITE_CONCERN_FAILED_CODE = 64;
+const UNSATISFIABLE_WRITE_CONCERN_CODE = 100;
+const UNKNOWN_REPL_WRITE_CONCERN_CODE = 79;
+const NON_DETERMINISTIC_WRITE_CONCERN_ERRORS = [
+  'CannotSatisfyWriteConcern',
+  'UnknownReplWriteConcern',
+  'UnsatisfiableWriteConcern'
+];
+
 function isWriteConcernTimeoutError(err) {
-  return err.code === 64 && !!(err.errInfo && err.errInfo.wtimeout === true);
+  return err.code === WRITE_CONCERN_FAILED_CODE && !!(err.errInfo && err.errInfo.wtimeout === true);
 }
 
 function isUnknownTransactionCommitResult(err) {
   return (
-    ['CannotSatisfyWriteConcern', 'UnknownReplWriteConcern', 'UnsatisfiableWriteConcern'].indexOf(
-      err.codeName
-    ) === -1
+    NON_DETERMINISTIC_WRITE_CONCERN_ERRORS.indexOf(err.codeName) === -1 &&
+    err.code !== UNSATISFIABLE_WRITE_CONCERN_CODE &&
+    err.code !== UNKNOWN_REPL_WRITE_CONCERN_CODE
   );
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -106,6 +106,16 @@ function collationNotSupported(server, cmd) {
   return cmd && cmd.collation && maxWireVersion(server) < 5;
 }
 
+/**
+ * Checks if a given value is a Promise
+ *
+ * @param {*} maybePromise
+ * @return true if the provided value is a Promise
+ */
+function isPromiseLike(maybePromise) {
+  return maybePromise && typeof maybePromise.then === 'function';
+}
+
 module.exports = {
   uuidV4,
   calculateDurationInMs,
@@ -113,5 +123,6 @@ module.exports = {
   collationNotSupported,
   retrieveEJSON,
   retrieveKerberos,
-  maxWireVersion
+  maxWireVersion,
+  isPromiseLike
 };


### PR DESCRIPTION
This is the core component (the meat) of NODE-1741. There were some design decisions made here, most notably that only a `Promise` may be returned from the lambda passed into `withTransaction`. Outside of that, this mostly follows the spec to the letter. 