### PR TITLE
fix(sessions): enable sessions in OP_MSG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,4 @@ jobs:
   allow_failures:
     - env:
         - MONGODB_VERSION=4.0.x
-        - MONGODB_ENVIRONMENT=replicaset
-    - env:
-        - MONGODB_VERSION=4.0.x
         - MONGODB_ENVIRONMENT=sharded

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -1207,15 +1207,18 @@ Pool.prototype.write = function(command, options, cb) {
     }
 
     // decorate the commands with session-specific details
+    let commandDocument = command;
     if (command instanceof Query) {
-      if (command.query.$query) {
-        Object.assign(command.query.$query, sessionOptions);
-      } else {
-        Object.assign(command.query, sessionOptions);
-      }
-    } else {
-      Object.assign(command, sessionOptions);
+      commandDocument = command.query;
+    } else if (command instanceof Msg) {
+      commandDocument = command.command;
     }
+
+    if (commandDocument.$query) {
+      commandDocument = commandDocument.$query;
+    }
+
+    Object.assign(commandDocument, sessionOptions);
   }
 
   // If command monitoring is enabled we need to modify the callback here


### PR DESCRIPTION
Sessions information is not presently applied to OP_MSG messages
because of a patch that was left out of the OP_MSG PR. The real
fix for this is to merge all of the sessions-related code in
our pool into the `command` wire protocol method, but that work
shouldn't hold up sessions support today.