### PR TITLE
refactor(handshake): pull out initial handshake into `connect`

### DIFF
--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -92,6 +92,7 @@ function performInitialHandshake(conn, options, callback) {
 
     if (!isSupportedServer(ismaster)) {
       const latestSupportedVersion = '2.6';
+      const latestSupportedMaxWireVersion = 2;
       const message =
         'Server at ' +
         options.host +
@@ -99,7 +100,9 @@ function performInitialHandshake(conn, options, callback) {
         options.port +
         ' reports wire version ' +
         (ismaster.maxWireVersion || 0) +
-        ', but this version of Node.js Driver requires at least 2 (MongoDB' +
+        ', but this version of Node.js Driver requires at least ' +
+        latestSupportedMaxWireVersion +
+        ' (MongoDB' +
         latestSupportedVersion +
         ').';
 

--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -48,6 +48,8 @@ function getSaslSupportedMechs(options) {
   }
 
   const credentials = options.credentials;
+
+  // TODO: revisit whether or not items like `options.user` and `options.dbName` should be checked here
   const authMechanism = credentials.mechanism;
   const authSource = credentials.source || options.dbName || 'admin';
   const user = credentials.username || options.user;

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -428,29 +428,14 @@ function dataHandler(conn) {
           data = data.slice(remainingBytesToRead);
 
           // Emit current complete message
-          try {
-            const emitBuffer = conn.buffer;
-            // Reset state of buffer
-            conn.buffer = null;
-            conn.sizeOfMessage = 0;
-            conn.bytesRead = 0;
-            conn.stubBuffer = null;
+          const emitBuffer = conn.buffer;
+          // Reset state of buffer
+          conn.buffer = null;
+          conn.sizeOfMessage = 0;
+          conn.bytesRead = 0;
+          conn.stubBuffer = null;
 
-            processMessage(conn, emitBuffer);
-          } catch (err) {
-            const errorObject = {
-              err: 'socketHandler',
-              trace: err,
-              bin: conn.buffer,
-              parseState: {
-                sizeOfMessage: conn.sizeOfMessage,
-                bytesRead: conn.bytesRead,
-                stubBuffer: conn.stubBuffer
-              }
-            };
-            // We got a parse Error fire it off then keep going
-            conn.emit('parseError', errorObject, conn);
-          }
+          processMessage(conn, emitBuffer);
         }
       } else {
         // Stub buffer is kept in case we don't get enough bytes to determine the
@@ -523,20 +508,16 @@ function dataHandler(conn) {
               sizeOfMessage < conn.maxBsonMessageSize &&
               sizeOfMessage === data.length
             ) {
-              try {
-                const emitBuffer = data;
-                // Reset state of buffer
-                conn.buffer = null;
-                conn.sizeOfMessage = 0;
-                conn.bytesRead = 0;
-                conn.stubBuffer = null;
-                // Exit parsing loop
-                data = Buffer.alloc(0);
-                // Emit the message
-                processMessage(conn, emitBuffer);
-              } catch (err) {
-                conn.emit('parseError', err, conn);
-              }
+              const emitBuffer = data;
+              // Reset state of buffer
+              conn.buffer = null;
+              conn.sizeOfMessage = 0;
+              conn.bytesRead = 0;
+              conn.stubBuffer = null;
+              // Exit parsing loop
+              data = Buffer.alloc(0);
+              // Emit the message
+              processMessage(conn, emitBuffer);
             } else if (sizeOfMessage <= 4 || sizeOfMessage > conn.maxBsonMessageSize) {
               const errorObject = {
                 err: 'socketHandler',

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -717,8 +717,10 @@ Pool.prototype.connect = function(credentials) {
         self.logger.debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
       }
 
-      // NOTE: when `err` exists, `connection` is actually the originating event name
-      connectionFailureHandler(self, connection, err);
+      if (self.state === CONNECTING) {
+        self.emit('error', err);
+      }
+
       return;
     }
 
@@ -739,7 +741,7 @@ Pool.prototype.connect = function(credentials) {
     if (self.options.inTopology) {
       stateTransition(self, CONNECTED);
       self.availableConnections.push(connection);
-      return self.emit('connect', self);
+      return self.emit('connect', self, connection);
     }
 
     reauthenticate(self, connection, function(err) {
@@ -771,7 +773,7 @@ Pool.prototype.connect = function(credentials) {
           }
         }
 
-        self.emit('connect', self);
+        self.emit('connect', self, connection);
       });
     });
   });


### PR DESCRIPTION
This removes the initial handshake code from the middle of the
Server topology implementation into our new `connect` method,
taking us one step closer to isolating all connection
initialization to a single location. The next step will be to
authenticate the connections.

NODE-1863