### PR TITLE
NODE-1435: move all auth to `connect`

### DIFF
--- a/lib/auth/auth_provider.js
+++ b/lib/auth/auth_provider.js
@@ -42,10 +42,8 @@ class AuthProvider {
         // If we have an error
         if (err) {
           errorObject = err;
-        } else if (r.result && r.result['$err']) {
-          errorObject = r.result;
-        } else if (r.result && r.result['errmsg']) {
-          errorObject = r.result;
+        } else if (r && (r.$err || r.errmsg)) {
+          errorObject = r;
         } else {
           numberOfValidConnections = numberOfValidConnections + 1;
         }

--- a/lib/auth/auth_provider.js
+++ b/lib/auth/auth_provider.js
@@ -41,9 +41,9 @@ class AuthProvider {
 
         // If we have an error
         if (err) {
-          errorObject = err;
+          errorObject = new MongoError(err);
         } else if (r && (r.$err || r.errmsg)) {
-          errorObject = r;
+          errorObject = new MongoError(r);
         } else {
           numberOfValidConnections = numberOfValidConnections + 1;
         }

--- a/lib/auth/gssapi.js
+++ b/lib/auth/gssapi.js
@@ -128,11 +128,10 @@ var MongoDBGSSAPIFirstStep = function(
   };
 
   // Write the commmand on the connection
-  sendAuthCommand(connection, '$external.$cmd', command, (err, r) => {
+  sendAuthCommand(connection, '$external.$cmd', command, (err, doc) => {
     if (err) return callback(err, false);
-    var doc = r.result;
     // Execute mongodb transition
-    mongo_auth_process.transition(r.result.payload, function(err, payload) {
+    mongo_auth_process.transition(doc.payload, function(err, payload) {
       if (err) return callback(err, false);
 
       // MongoDB API Second Step
@@ -177,9 +176,8 @@ var MongoDBGSSAPISecondStep = function(
 
   // Execute the command
   // Write the commmand on the connection
-  sendAuthCommand(connection, '$external.$cmd', command, (err, r) => {
+  sendAuthCommand(connection, '$external.$cmd', command, (err, doc) => {
     if (err) return callback(err, false);
-    var doc = r.result;
     // Call next transition for kerberos
     mongo_auth_process.transition(doc.payload, function(err, payload) {
       if (err) return callback(err, false);

--- a/lib/auth/mongocr.js
+++ b/lib/auth/mongocr.js
@@ -24,7 +24,7 @@ class MongoCR extends AuthProvider {
 
       // Get nonce
       if (err == null) {
-        nonce = r.result.nonce;
+        nonce = r.nonce;
         // Use node md5 generator
         let md5 = crypto.createHash('md5');
         // Generate keys used for authentication

--- a/lib/auth/scram.js
+++ b/lib/auth/scram.js
@@ -122,7 +122,7 @@ class ScramSHA extends AuthProvider {
     }
 
     if (r.$err || r.errmsg) {
-      return r;
+      return new MongoError(r);
     }
   }
 

--- a/lib/auth/sspi.js
+++ b/lib/auth/sspi.js
@@ -90,9 +90,8 @@ function SSIPAuthenticate(
         autoAuthorize: 1
       };
 
-      authCommand(command, (err, result) => {
+      authCommand(command, (err, doc) => {
         if (err) return callback(err, false);
-        const doc = result.result;
 
         authProcess.transition(doc.payload, (err, payload) => {
           if (err) return callback(err, false);
@@ -102,9 +101,8 @@ function SSIPAuthenticate(
             payload
           };
 
-          authCommand(command, (err, result) => {
+          authCommand(command, (err, doc) => {
             if (err) return callback(err, false);
-            const doc = result.result;
 
             authProcess.transition(doc.payload, (err, payload) => {
               if (err) return callback(err, false);

--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -316,8 +316,8 @@ function authenticate(conn, credentials, callback) {
   }
 
   const provider = AUTH_PROVIDERS[mechanism];
-  provider.auth(runCommand, [conn], credentials, () => {
-    console.log('authed through provider!');
+  provider.auth(runCommand, [conn], credentials, err => {
+    if (err) return callback(err);
     callback(null, conn);
   });
 }

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -284,9 +284,14 @@ function makeCommandWriter(self) {
       numberToReturn: 1
     });
 
+    function wrappedCallback(err, r) {
+      if (err) return callback(err);
+      callback(null, r.result);
+    }
+
     // Set the connection workItem callback
     connection.workItems.push({
-      cb: callback,
+      cb: wrappedCallback,
       command: true,
       requestId: query.requestId
     });

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -456,8 +456,6 @@ var eventHandler = function(self, event) {
 
 /**
  * Initiate server connect
- * @method
- * @param {MongoCredentials} [options.credentials] MongoCredentials object for auth
  */
 Server.prototype.connect = function(options) {
   var self = this;
@@ -497,8 +495,17 @@ Server.prototype.connect = function(options) {
     address: self.name
   });
 
-  // Connect with optional auth settings
-  self.s.pool.connect(options.credentials);
+  self.s.pool.connect();
+};
+
+/**
+ * Authenticate the topology.
+ * @method
+ * @param {MongoCredentials} credentials The credentials for authentication we are using
+ * @param {authResultCallback} callback A callback function
+ */
+Server.prototype.auth = function(credentials, callback) {
+  callback(null, null);
 };
 
 /**
@@ -746,39 +753,6 @@ Server.prototype.cursor = function(ns, cmd, options) {
 
   // Return the cursor
   return new FinalCursor(this.s.bson, ns, cmd, options, topology, this.s.options);
-};
-
-/**
- * Logout from a database
- * @method
- * @param {string} db The db we are logging out from
- * @param {authResultCallback} callback A callback function
- */
-Server.prototype.logout = function(dbName, callback) {
-  this.s.pool.logout(dbName, callback);
-};
-
-/**
- * Authenticate using a specified mechanism
- * @method
- * @param {MongoCredentials} credentials Authentication credentials for login
- * @param {authResultCallback} callback A callback function
- */
-Server.prototype.auth = function(credentials, callback) {
-  credentials.resolveAuthMechanism(this.ismaster);
-
-  // If we are not connected or have a disconnectHandler specified
-  if (disconnectHandler(this, 'auth', credentials.source, [credentials, callback], {}, callback)) {
-    return;
-  }
-
-  // Do not authenticate if we are an arbiter
-  if (this.lastIsMaster() && this.lastIsMaster().arbiterOnly) {
-    return callback(null, true);
-  }
-
-  // Apply the arguments to the pool
-  this.s.pool.auth(credentials, callback);
 };
 
 /**

--- a/test/tests/unit/replset/auth_tests.js
+++ b/test/tests/unit/replset/auth_tests.js
@@ -29,6 +29,7 @@ describe('Auth (ReplSet)', function() {
 
     let finish = err => {
       finish = () => {};
+      replSet.destroy({ force: true });
       done(err);
     };
 
@@ -58,12 +59,12 @@ describe('Auth (ReplSet)', function() {
         connectionTimeout: 3000,
         disconnectHandler: mockDisconnectHandler,
         secondaryOnlyConnectionAllowed: true,
-        size: 1
+        size: 1,
+        credentials
       }
     );
 
     replSet.once('error', finish);
-    replSet.once('connect', () => replSet.auth(credentials, () => {}));
     replSet.connect({
       readPreference: new ReadPreference('primary'),
       checkServerIdentity: true,

--- a/test/tests/unit/scram_iterations_tests.js
+++ b/test/tests/unit/scram_iterations_tests.js
@@ -48,23 +48,19 @@ describe('SCRAM Iterations Tests', function() {
       }
     });
 
-    const client = new Server(test.server.address());
-    client.on('error', done);
-    client.once('connect', server => {
-      server.auth(credentials, (err, result) => {
-        let testErr;
-        try {
-          expect(err).to.not.be.null;
-          expect(err)
-            .to.have.property('message')
-            .that.matches(/Server returned an invalid iteration count/);
-          expect(result).to.be.false;
-        } catch (e) {
-          testErr = e;
-        }
-        client.destroy();
-        done(testErr);
-      });
+    const client = new Server(Object.assign({}, test.server.address(), { credentials }));
+    client.on('error', err => {
+      let testErr;
+      try {
+        expect(err).to.not.be.null;
+        expect(err)
+          .to.have.property('message')
+          .that.matches(/Server returned an invalid iteration count/);
+      } catch (e) {
+        testErr = e;
+      }
+      client.destroy();
+      done(testErr);
     });
 
     client.connect();


### PR DESCRIPTION
**NOTE:** this PR is a little big until the previous one is reviewed and merged

This moves all authentication in the entire driver into the `connect` method, greatly simplifying our view of auth in the module. Top-level methods still exist on all of the topologies, but they are no-ops that immediately call back with no error. 