### PR TITLE
fix(uri_parser): restore original compression parsing

### DIFF
--- a/lib/uri_parser.js
+++ b/lib/uri_parser.js
@@ -264,6 +264,12 @@ function applyConnectionStringOption(obj, key, value, options) {
     throw new MongoParseError('zlibCompressionLevel must be an integer between -1 and 9');
   }
 
+  // special cases
+  if (key === 'compressors' || key === 'zlibcompressionlevel') {
+    obj.compression = obj.compression || {};
+    obj = obj.compression;
+  }
+
   if (key === 'authmechanismproperties') {
     if (typeof value.SERVICE_NAME === 'string') obj.gssapiServiceName = value.SERVICE_NAME;
     if (typeof value.SERVICE_REALM === 'string') obj.gssapiServiceRealm = value.SERVICE_REALM;

--- a/test/tests/unit/connection_string_tests.js
+++ b/test/tests/unit/connection_string_tests.js
@@ -100,8 +100,11 @@ describe('Connection String', function() {
       'mongodb://localhost/?compressors=zlib&zlibCompressionLevel=4',
       (err, result) => {
         expect(err).to.not.exist;
-        expect(result.options.compressors).to.eql(['zlib']);
-        expect(result.options.zlibCompressionLevel).to.equal(4);
+        expect(result.options).to.have.property('compression');
+        expect(result.options.compression).to.eql({
+          compressors: ['zlib'],
+          zlibCompressionLevel: 4
+        });
 
         done();
       }


### PR DESCRIPTION
In #410, I removed the special case for `compression` but I intended to leave it in after Matt had some questions around whether it would break compression in native. This PR is to restore the original `compression` special case code and accompanying test. 