### PR TITLE
APM for "serialize command" step

### DIFF
--- a/lib/connection/apm.js
+++ b/lib/connection/apm.js
@@ -190,17 +190,21 @@ class CommandSucceededEvent {
    * @param {Object} command the command
    * @param {Object} reply the reply for this command from the server
    * @param {Array} started a high resolution tuple timestamp of when the command was first sent, to calculate duration
+   * @param {Array} metadata an array of command metadata
    */
-  constructor(pool, command, reply, started) {
+  constructor(pool, command, reply, started, metadata) {
     const cmd = extractCommand(command);
     const commandName = extractCommandName(cmd);
+    metadata = Array.isArray(metadata) ? metadata : [];
+    const commandMetadata = new CommandMetadata(metadata);
 
     Object.assign(this, {
       duration: calculateDurationInMs(started),
       commandName,
       reply: maybeRedact(commandName, extractReply(command, reply)),
       requestId: command.requestId,
-      connectionId: generateConnectionId(pool)
+      connectionId: generateConnectionId(pool),
+      metadata: commandMetadata
     });
   }
 }
@@ -214,23 +218,60 @@ class CommandFailedEvent {
    * @param {Object} command the command
    * @param {MongoError|Object} error the generated error or a server error response
    * @param {Array} started a high resolution tuple timestamp of when the command was first sent, to calculate duration
+   * @param {Array} metadata an array of command metadata
    */
-  constructor(pool, command, error, started) {
+  constructor(pool, command, error, started, metadata) {
     const cmd = extractCommand(command);
     const commandName = extractCommandName(cmd);
+    metadata = (Array.isArray(metadata) && metadata) || [];
+    const commandMetadata = new CommandMetadata(metadata);
 
     Object.assign(this, {
       duration: calculateDurationInMs(started),
       commandName,
       failure: maybeRedact(commandName, error),
       requestId: command.requestId,
-      connectionId: generateConnectionId(pool)
+      connectionId: generateConnectionId(pool),
+      metadata: commandMetadata
     });
+  }
+}
+
+class BSONSerializationData {
+  /**
+   * Create serialize operation data, to store data about the serialize operation within a command's execution
+   *
+   * @param {Array} serializedBuffers the array of buffers that were serialized
+   * @param {Array} started a high resolution tuple timestamp of when the command started to serialize, to calculate duration
+   */
+  constructor(serializedBuffers, started) {
+    serializedBuffers = serializedBuffers || [];
+    started = started || [];
+    Object.assign(this, {
+      type: 'bsonSerialization',
+      buffersLength: serializedBuffers.reduce((s, b) => s + b.length, 0),
+      duration: calculateDurationInMs(started)
+    });
+  }
+}
+
+class CommandMetadata {
+  /**
+   * Create command metadata, to store data about operations that take place within a command's execution
+   *
+   * @param {Array} stepsData an array of command step data
+   */
+  constructor(stepsData) {
+    stepsData.reduce((self, step) => {
+      self[step.type] = step;
+      return self;
+    }, this);
   }
 }
 
 module.exports = {
   CommandStartedEvent,
   CommandSucceededEvent,
-  CommandFailedEvent
+  CommandFailedEvent,
+  BSONSerializationData
 };

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -895,6 +895,8 @@ Pool.prototype.write = function(command, options, cb) {
   // Get the requestId
   operation.requestId = command.requestId;
 
+  const metadata = [];
+  let serializeStarted;
   // If command monitoring is enabled we need to modify the callback here
   if (self.options.monitorCommands) {
     this.emit('commandStarted', new apm.CommandStartedEvent(this, command));
@@ -904,28 +906,34 @@ Pool.prototype.write = function(command, options, cb) {
       if (err) {
         self.emit(
           'commandFailed',
-          new apm.CommandFailedEvent(this, command, err, operation.started)
+          new apm.CommandFailedEvent(this, command, err, operation.started, metadata)
         );
       } else {
         if (reply && reply.result && (reply.result.ok === 0 || reply.result.$err)) {
           self.emit(
             'commandFailed',
-            new apm.CommandFailedEvent(this, command, reply.result, operation.started)
+            new apm.CommandFailedEvent(this, command, reply.result, operation.started, metadata)
           );
         } else {
           self.emit(
             'commandSucceeded',
-            new apm.CommandSucceededEvent(this, command, reply, operation.started)
+            new apm.CommandSucceededEvent(this, command, reply, operation.started, metadata)
           );
         }
       }
 
       if (typeof cb === 'function') cb(err, reply);
     };
+
+    serializeStarted = process.hrtime();
   }
 
   // Prepare the operation buffer
   serializeCommand(self, command, (err, serializedBuffers) => {
+    if (this.options.monitorCommands) {
+      metadata.push(new apm.BSONSerializationData(serializedBuffers, serializeStarted));
+    }
+
     if (err) throw err;
 
     // Set the operation's buffer to the serialization of the commands


### PR DESCRIPTION
Opening up this PR for discussion, not meant to be the final version.

# What?
This changes creates three new APM events, related to the `serializeCommand` operation.

# Why?
The `CommandXEvent`s are very good for high level visibility but lack details. As an engineer that has developed with node.js + MongoDB for a while, I've usually found myself wanting to separate:

1. MongoDB server/DB side command execution time
1. MongoDB client side command execution time delays, especially related to serialization

Item #2 can be particularly useful to identify either updates/inserts of large document sets (which are bad because serialization time blocks the event loop) and large result sets from queries (not in this PR).

# Next steps
Would love to get the team's feedback to learn:

- If this is believed to be useful
- If this is the best approach to achieve this. For example we could alternatively move all the logic into `serializeCommand`, which would be appropriate if other calls are added in the future.

I already have the code ready to relay the events in the (native)[https://github.com/mongodb/node-mongodb-native] repo as well. This is what the events look like when logged to the console:
```
serializationSucceeded SerializeCommandSucceededEvent {
  duration: 7.135826,
  commandName: 'insert',
  buffersLength: 2097337,
  requestId: 2,
  connectionId: 'localhost:27017' }
```

In this case as a developer I could consider the `duration` and `buffersLength` to be fairly high. This can then be either sent to metrics, logs and even tracing services with the appropriate context tracking.

Also, if this is useful I'd like to explore doing the same thing for "deserialization time", aiming to expose timing and size metrics about query results, e.g. knowing about `find` queries that returns > 1MB of size and block the event loop while deserializing such a big chunk of data.