### PR TITLE
fix(uri-parser): always treat appname as a string

### DIFF
--- a/lib/uri_parser.js
+++ b/lib/uri_parser.js
@@ -124,6 +124,10 @@ function parseQueryStringItemValue(key, value) {
     // deduplicate and simplify arrays
     value = value.filter((v, idx) => value.indexOf(v) === idx);
     if (value.length === 1) value = value[0];
+  } else if (STRING_OPTIONS.has(key)) {
+    // TODO: refactor function to make this early return not
+    // stand out
+    return value;
   } else if (value.indexOf(':') > 0) {
     value = value.split(',').reduce((result, pair) => {
       const parts = pair.split(':');
@@ -136,7 +140,7 @@ function parseQueryStringItemValue(key, value) {
     });
   } else if (value.toLowerCase() === 'true' || value.toLowerCase() === 'false') {
     value = value.toLowerCase() === 'true';
-  } else if (!Number.isNaN(value) && !STRING_OPTIONS.has(key)) {
+  } else if (!Number.isNaN(value)) {
     const numericValue = parseFloat(value);
     if (!Number.isNaN(numericValue)) {
       value = parseFloat(value);
@@ -157,8 +161,9 @@ const BOOLEAN_OPTIONS = new Set([
   'j'
 ]);
 
-// Known string options, only used to bypass Number coercion in `parseQueryStringItemValue`
-const STRING_OPTIONS = new Set(['authsource', 'replicaset']);
+// Known string options
+// TODO: Do this for more types
+const STRING_OPTIONS = new Set(['authsource', 'replicaset', 'appname']);
 
 // Supported text representations of auth mechanisms
 // NOTE: this list exists in native already, if it is merged here we should deduplicate

--- a/test/tests/unit/connection_string_tests.js
+++ b/test/tests/unit/connection_string_tests.js
@@ -177,6 +177,20 @@ describe('Connection String', function() {
     );
   });
 
+  it('should not parse appname as an object when colon is present', function(done) {
+    parseConnectionString('mongodb://localhost/?appname=foo:bar:baz', (err, result) => {
+      try {
+        expect(err).to.not.exist;
+        expect(result)
+          .to.have.property('options')
+          .that.has.property('appname', 'foo:bar:baz');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
   describe('validation', function() {
     it('should validate compression options', function(done) {
       parseConnectionString('mongodb://localhost/?zlibCompressionLevel=15', err => {


### PR DESCRIPTION
Fixes NODE-1983

Needs to be ported to `next`