### PR TITLE
fix(pool): clean up connections if pool is destroyed mid-handshake

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -561,6 +561,7 @@ Pool.prototype.connect = function() {
     }
 
     if (self.state === DESTROYED || self.state === DESTROYING) {
+      connection.destroy();
       return self.destroy();
     }
 


### PR DESCRIPTION
A temporary fix that will ensure that if a connection is mid-handshake when the pool is closed, it will be destroyed as soon as the handshake call settles.

Fixes NODE-1971

needs to be ported to `node-mongodb-native#next`