### PR TITLE
fix(server): emit "first connect" error if initial connect fails due to ECONNREFUSED

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -421,7 +421,7 @@ var eventHandler = function(self, event) {
 
       // On first connect fail
       if (
-        self.s.pool.state === 'disconnected' &&
+        ['disconnected', 'connecting'].indexOf(self.s.pool.state) !== -1 &&
         self.initialConnect &&
         ['close', 'timeout', 'error', 'parseError'].indexOf(event) !== -1
       ) {


### PR DESCRIPTION
Admittedly this is a minor detail, but when connecting to a standalone server that is currently down using the below script:

```javascript
const mongodb = require('mongodb');

const connectionString = `mongodb://localhost:27017/test`;

run().then(() => console.log('done')).catch(error => console.error(error.stack));

async function run() {
  await mongodb.MongoClient.connect(connectionString, { useNewUrlParser: true, connectTimeoutMS: 5000 });
}
```

You get the below error message:

```
Error: connect ECONNREFUSED 127.0.0.1:27017
    at Object._errnoException (util.js:1022:11)
    at _exceptionWithHostPort (util.js:1044:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1182:14)
```

This error gets bubbled up because for some reason the pool hasn't transitioned its state from 'CONNECTING' to 'DISCONNECTED' when the code that's supposed to format the error runs. With this change, you instead get the below error:

```
MongoNetworkError: failed to connect to server [localhost:27017] on first connect [MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017]
    at Pool.<anonymous> (/home/val/Workspace/MongoDB/mongoose/node_modules/mongodb-core/lib/topologies/server.js:432:11)
    at emitOne (events.js:116:13)
    at Pool.emit (events.js:211:7)
    at connect (/home/val/Workspace/MongoDB/mongoose/node_modules/mongodb-core/lib/connection/pool.js:557:14)
    at makeConnection (/home/val/Workspace/MongoDB/mongoose/node_modules/mongodb-core/lib/connection/connect.js:39:11)
    at callback (/home/val/Workspace/MongoDB/mongoose/node_modules/mongodb-core/lib/connection/connect.js:261:5)
    at Socket.err (/home/val/Workspace/MongoDB/mongoose/node_modules/mongodb-core/lib/connection/connect.js:286:7)
    at Object.onceWrapper (events.js:315:30)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at emitErrorNT (internal/streams/destroy.js:64:8)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

Re: https://github.com/Automattic/mongoose/issues/7768