### PR TITLE
retry with family=0 when family=6,4 throws ENOTFOUND

### DIFF
--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -36,8 +36,20 @@ function connect(options, callback) {
     if (err) {
       makeConnection(4, options, (err, ipv4Socket) => {
         if (err) {
-          callback(err, ipv4Socket); // in the error case, `ipv4Socket` is the originating error event name
-          return;
+          makeConnection(0, options, (err, ipDefaultSocket) => {
+            if (err) {
+              callback(err, ipDefaultSocket) 
+              return
+            }
+
+            performInitialHandshake(
+              new Connection(ipDefaultSocket, options),
+              options,
+              callback
+            )
+          })
+
+          return
         }
 
         performInitialHandshake(new Connection(ipv4Socket, options), options, callback);


### PR DESCRIPTION
In 2.x.x versions of the MongoDB Driver the connection was made in this way:
`dns.lookup(host, () => {...})`. This type of lookup uses a default IP family of 0 in the dns library.
WIth 3.x.x versions of the driver the lookup is first tried with IPv6, then with IPv4 and if both fail the connection fails.
However the lookup would still work with the method used in 2.x.x, with the family defaulting to 0.
