### PR TITLE
fix(server): bubble up pool 'attemptReconnect' event

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -480,6 +480,7 @@ Server.prototype.connect = function(options) {
   self.s.pool.on('connect', eventHandler(self, 'connect'));
   self.s.pool.on('reconnect', eventHandler(self, 'reconnect'));
   self.s.pool.on('reconnectFailed', eventHandler(self, 'reconnectFailed'));
+  self.s.pool.on('attemptReconnect', eventHandler(self, 'attemptReconnect'));
 
   // Set up listeners for command monitoring
   relayEvents(self.s.pool, self, ['commandStarted', 'commandSucceeded', 'commandFailed']);


### PR DESCRIPTION
Re: Automattic/mongoose#7872. Pools emit an 'attemptReconnect' event every time they attempt to reconnect to the server, and [the end user driver is already configured to bubble up the 'attemptReconnect' event](https://github.com/mongodb/node-mongodb-native/blob/3105625c2973210eb531ada35a2ec121d8fe89c2/lib/topologies/server.js), the only thing missing is that the core topology doesn't bubble up the event.