### PR TITLE
fix(connect): don't treat 'connect' event as an error

### DIFF
--- a/lib/connection/connect.js
+++ b/lib/connection/connect.js
@@ -278,7 +278,7 @@ function makeConnection(family, options, _callback) {
   socket.setTimeout(connectionTimeout);
   socket.setNoDelay(noDelay);
 
-  const errorEvents = ['error', 'close', 'timeout', 'parseError', 'connect'];
+  const errorEvents = ['error', 'close', 'timeout', 'parseError'];
   function errorHandler(eventName) {
     return err => {
       errorEvents.forEach(event => socket.removeAllListeners(event));


### PR DESCRIPTION
I did some digging to figure out why angular universal doesn't seem to work when connecting to Atlas (https://github.com/Automattic/mongoose/issues/7838) and found an interesting quirk that may or may not be a bug.

The reason why angular universal fails is that, because of how Zone.js monkey-patches event emitters to be cancellable, `connectHandler()` cancels itself by calling `removeAllListeners('connect')` because it removes all listeners from all error events. I'm not sure why 'connect' is listed as an error event. Removing it seems to not break anything and at least enable Mongoose to connect to Atlas in angular universal.

I realize this is a risky change and might be worth waiting until a minor or major release, but I don't see how this could break anything. I might be missing something though, my brain is fried from too much staring at Angular code :p 