### PR TITLE
fix(replset): correct legacy max staleness calculation

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -414,10 +414,10 @@ var pingServer = function(self, server, cb) {
 
       // Calculate latency
       var latencyMS = new Date().getTime() - start;
+
       // Set the last updatedTime
-      var hrTime = process.hrtime();
-      // Calculate the last update time
-      server.lastUpdateTime = hrTime[0] * 1000 + Math.round(hrTime[1] / 1000);
+      var hrtime = process.hrtime();
+      server.lastUpdateTime = (hrtime[0] * 1e9 + hrtime[1]) / 1e6;
 
       // We had an error, remove it from the state
       if (err) {


### PR DESCRIPTION
We were calculating lastUpdateTime using nanoseconds instead of
milliseconds, despite calculating maxStaleness with a millisecond
lastWriteDate